### PR TITLE
Auto-unsubscribe implementations and fixes

### DIFF
--- a/NATS.Client.sln.DotSettings
+++ b/NATS.Client.sln.DotSettings
@@ -3,4 +3,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CR/@EntryIndexedValue">CR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LF/@EntryIndexedValue">LF</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HMSG/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=HPUB/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HPUB/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Msgs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NATS.Client.Core/Commands/SubscribeCommand.cs
+++ b/src/NATS.Client.Core/Commands/SubscribeCommand.cs
@@ -7,12 +7,13 @@ internal sealed class AsyncSubscribeCommand : AsyncCommandBase<AsyncSubscribeCom
     private string? _subject;
     private string? _queueGroup;
     private int _sid;
+    private int? _maxMsgs;
 
     private AsyncSubscribeCommand()
     {
     }
 
-    public static AsyncSubscribeCommand Create(ObjectPool pool, CancellationTimer timer, int sid, string subject, string? queueGroup)
+    public static AsyncSubscribeCommand Create(ObjectPool pool, CancellationTimer timer, int sid, string subject, string? queueGroup, int? maxMsgs)
     {
         if (!TryRent(pool, out var result))
         {
@@ -22,6 +23,7 @@ internal sealed class AsyncSubscribeCommand : AsyncCommandBase<AsyncSubscribeCom
         result._subject = subject;
         result._sid = sid;
         result._queueGroup = queueGroup;
+        result._maxMsgs = maxMsgs;
         result.SetCancellationTimer(timer);
 
         return result;
@@ -29,7 +31,7 @@ internal sealed class AsyncSubscribeCommand : AsyncCommandBase<AsyncSubscribeCom
 
     public override void Write(ProtocolWriter writer)
     {
-        writer.WriteSubscribe(_sid, _subject!, _queueGroup);
+        writer.WriteSubscribe(_sid, _subject!, _queueGroup, _maxMsgs);
     }
 
     protected override void Reset()
@@ -42,13 +44,13 @@ internal sealed class AsyncSubscribeCommand : AsyncCommandBase<AsyncSubscribeCom
 
 internal sealed class AsyncSubscribeBatchCommand : AsyncCommandBase<AsyncSubscribeBatchCommand>, IBatchCommand
 {
-    private (int sid, string subject, string? queueGroup)[]? _subscriptions;
+    private (int sid, string subject, string? queueGroup, int? maxMsgs)[]? _subscriptions;
 
     private AsyncSubscribeBatchCommand()
     {
     }
 
-    public static AsyncSubscribeBatchCommand Create(ObjectPool pool, CancellationTimer timer, (int sid, string subject, string? queueGroup)[]? subscriptions)
+    public static AsyncSubscribeBatchCommand Create(ObjectPool pool, CancellationTimer timer, (int sid, string subject, string? queueGroup, int? maxMsgs)[]? subscriptions)
     {
         if (!TryRent(pool, out var result))
         {
@@ -71,10 +73,10 @@ internal sealed class AsyncSubscribeBatchCommand : AsyncCommandBase<AsyncSubscri
         var i = 0;
         if (_subscriptions != null)
         {
-            foreach (var (id, subject, queue) in _subscriptions)
+            foreach (var (id, subject, queue, maxMsgs) in _subscriptions)
             {
                 i++;
-                writer.WriteSubscribe(id, subject, queue);
+                writer.WriteSubscribe(id, subject, queue, maxMsgs);
             }
         }
 

--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -27,7 +27,7 @@ public interface INatsConnection
     /// <param name="msg">A <see cref="NatsMsg"/> representing message details.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the command.</param>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous send operation.</returns>
-    ValueTask PublishAsync(NatsMsg msg, CancellationToken cancellationToken = default);
+    ValueTask PublishAsync(in NatsMsg msg, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes a serializable message payload to the given subject name, optionally supplying a reply subject.
@@ -47,7 +47,7 @@ public interface INatsConnection
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the command.</param>
     /// <typeparam name="T">Specifies the type of data that may be send to the NATS Server.</typeparam>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous send operation.</returns>
-    ValueTask PublishAsync<T>(NatsMsg<T> msg, CancellationToken cancellationToken = default);
+    ValueTask PublishAsync<T>(in NatsMsg<T> msg, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Initiates a subscription to a subject, optionally joining a distributed queue group.

--- a/src/NATS.Client.Core/INatsSub.cs
+++ b/src/NATS.Client.Core/INatsSub.cs
@@ -9,25 +9,33 @@ internal interface INatsSub : IAsyncDisposable
 
     string? QueueGroup { get; }
 
+    int? PendingMsgs { get; }
+
     int Sid { get; }
 
-    ValueTask ReceiveAsync(string subject, string? replyTo, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer);
+    /// <summary>
+    /// Called after subscription is sent to the server.
+    /// Helps maintain more accurate timeouts, especially idle timeout.
+    /// </summary>
+    void Ready();
+
+    ValueTask ReceiveAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
 }
 
 internal interface INatsSubBuilder<out T>
     where T : INatsSub
 {
-    T Build(string subject, string? queueGroup, NatsConnection connection, SubscriptionManager manager);
+    T Build(string subject, NatsSubOpts? opts, NatsConnection connection, SubscriptionManager manager);
 }
 
 internal class NatsSubBuilder : INatsSubBuilder<NatsSub>
 {
     public static readonly NatsSubBuilder Default = new();
 
-    public NatsSub Build(string subject, string? queueGroup, NatsConnection connection, SubscriptionManager manager)
+    public NatsSub Build(string subject, NatsSubOpts? opts, NatsConnection connection, SubscriptionManager manager)
     {
         var sid = manager.GetNextSid();
-        return new NatsSub(connection, manager, subject, queueGroup, sid);
+        return new NatsSub(connection, manager, subject, opts, sid);
     }
 }
 
@@ -41,9 +49,9 @@ internal class NatsSubModelBuilder<T> : INatsSubBuilder<NatsSub<T>>
     public static NatsSubModelBuilder<T> For(INatsSerializer serializer) =>
         Cache.GetOrAdd(serializer, static s => new NatsSubModelBuilder<T>(s));
 
-    public NatsSub<T> Build(string subject, string? queueGroup, NatsConnection connection, SubscriptionManager manager)
+    public NatsSub<T> Build(string subject, NatsSubOpts? opts, NatsConnection connection, SubscriptionManager manager)
     {
         var sid = manager.GetNextSid();
-        return new NatsSub<T>(connection, manager, subject, queueGroup, sid, _serializer);
+        return new NatsSub<T>(connection, manager, subject, opts, sid, _serializer);
     }
 }

--- a/src/NATS.Client.Core/NatsConnection.LowLevelApi.cs
+++ b/src/NATS.Client.Core/NatsConnection.LowLevelApi.cs
@@ -57,19 +57,19 @@ public partial class NatsConnection
         }
     }
 
-    internal ValueTask<T> SubAsync<T>(string subject, string? queueGroup, INatsSubBuilder<T> builder, CancellationToken cancellationToken = default)
+    internal ValueTask<T> SubAsync<T>(string subject, NatsSubOpts? opts, INatsSubBuilder<T> builder, CancellationToken cancellationToken = default)
         where T : INatsSub
     {
-        var sub = builder.Build(subject, queueGroup, this, _subscriptionManager);
+        var sub = builder.Build(subject, opts, connection: this, _subscriptionManager);
         if (ConnectionState == NatsConnectionState.Open)
         {
-            return _subscriptionManager.SubscribeAsync(subject, queueGroup, sub, cancellationToken);
+            return _subscriptionManager.SubscribeAsync(subject, opts, sub, cancellationToken);
         }
         else
         {
-            return WithConnectAsync(subject, queueGroup, sub, cancellationToken, static (self, s, qg, sb, token) =>
+            return WithConnectAsync(subject, opts, sub, cancellationToken, static (self, s, o, sb, token) =>
             {
-                return self._subscriptionManager.SubscribeAsync(s, qg, sb, token);
+                return self._subscriptionManager.SubscribeAsync(s, o, sb, token);
             });
         }
     }

--- a/src/NATS.Client.Core/NatsConnection.Publish.cs
+++ b/src/NATS.Client.Core/NatsConnection.Publish.cs
@@ -11,7 +11,7 @@ public partial class NatsConnection
     }
 
     /// <inheritdoc />
-    public ValueTask PublishAsync(NatsMsg msg, CancellationToken cancellationToken = default)
+    public ValueTask PublishAsync(in NatsMsg msg, CancellationToken cancellationToken = default)
     {
         return PublishAsync(msg.Subject, msg.Data, default, cancellationToken);
     }
@@ -24,7 +24,7 @@ public partial class NatsConnection
     }
 
     /// <inheritdoc />
-    public ValueTask PublishAsync<T>(NatsMsg<T> msg, CancellationToken cancellationToken = default)
+    public ValueTask PublishAsync<T>(in NatsMsg<T> msg, CancellationToken cancellationToken = default)
     {
         return PublishAsync<T>(msg.Subject, msg.Data, default, cancellationToken);
     }

--- a/src/NATS.Client.Core/NatsConnection.Subscribe.cs
+++ b/src/NATS.Client.Core/NatsConnection.Subscribe.cs
@@ -7,13 +7,13 @@ public partial class NatsConnection
     /// <inheritdoc />
     public ValueTask<NatsSub> SubscribeAsync(string subject, in NatsSubOpts? opts = default, CancellationToken cancellationToken = default)
     {
-        return SubAsync<NatsSub>(subject, opts?.QueueGroup, NatsSubBuilder.Default, cancellationToken);
+        return SubAsync<NatsSub>(subject, opts, NatsSubBuilder.Default, cancellationToken);
     }
 
     /// <inheritdoc />
     public ValueTask<NatsSub<T>> SubscribeAsync<T>(string subject, in NatsSubOpts? opts = default, CancellationToken cancellationToken = default)
     {
         var serializer = opts?.Serializer ?? Options.Serializer;
-        return SubAsync<NatsSub<T>>(subject, opts?.QueueGroup, NatsSubModelBuilder<T>.For(serializer), cancellationToken);
+        return SubAsync<NatsSub<T>>(subject, opts, NatsSubModelBuilder<T>.For(serializer), cancellationToken);
     }
 }

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -190,9 +190,9 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
     }
 
     // called only internally
-    internal ValueTask SubscribeCoreAsync(int sid, string subject, string? queueGroup, CancellationToken cancellationToken)
+    internal ValueTask SubscribeCoreAsync(int sid, string subject, string? queueGroup, int? maxMsgs, CancellationToken cancellationToken)
     {
-        var command = AsyncSubscribeCommand.Create(_pool, GetCancellationTimer(cancellationToken), sid, subject, queueGroup);
+        var command = AsyncSubscribeCommand.Create(_pool, GetCancellationTimer(cancellationToken), sid, subject, queueGroup, maxMsgs);
         return EnqueueAndAwaitCommandAsync(command);
     }
 
@@ -776,6 +776,12 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
     {
         await ConnectAsync().ConfigureAwait(false);
         return await coreAsync(this, item1, item2, item3, item4).ConfigureAwait(false);
+    }
+
+    private async ValueTask<TResult> WithConnectAsync<T1, T2, T3, T4, T5, TResult>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, Func<NatsConnection, T1, T2, T3, T4, T5, ValueTask<TResult>> coreAsync)
+    {
+        await ConnectAsync().ConfigureAwait(false);
+        return await coreAsync(this, item1, item2, item3, item4, item5).ConfigureAwait(false);
     }
 }
 

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -3,33 +3,170 @@ using System.Threading.Channels;
 
 namespace NATS.Client.Core;
 
+internal enum NatsSubEndReason
+{
+    None,
+    MaxMsgs,
+    Timeout,
+    IdleTimeout,
+}
+
 public abstract class NatsSubBase : INatsSub
 {
-    internal NatsSubBase(NatsConnection connection, SubscriptionManager manager, string subject, string? queueGroup, int sid)
+    private readonly int _sid;
+    private readonly SubscriptionManager _manager;
+    private readonly Timer? _timeoutTimer;
+    private readonly Timer? _idleTimeoutTimer;
+    private readonly TimeSpan _idleTimeout;
+    private readonly TimeSpan _timeout;
+    private readonly bool _countPendingMsgs;
+    private bool _disposed;
+    private bool _unsubscribed;
+    private bool _endSubscription;
+    private int _endReasonRaw;
+    private int _pendingMsgs;
+
+    internal NatsSubBase(NatsConnection connection, SubscriptionManager manager, string subject, NatsSubOpts? opts, int sid)
     {
+        _sid = sid;
+        _manager = manager;
+        _pendingMsgs = opts is { MaxMsgs: > 0 } ? opts.Value.MaxMsgs ?? -1 : -1;
+        _countPendingMsgs = _pendingMsgs > 0;
+        _idleTimeout = opts?.IdleTimeout ?? default;
+        _timeout = opts?.Timeout ?? default;
+
         Connection = connection;
-        Manager = manager;
         Subject = subject;
-        QueueGroup = queueGroup;
-        Sid = sid;
+        QueueGroup = opts?.QueueGroup;
+
+        // Only allocate timers if necessary to reduce GC pressure
+        if (_idleTimeout != default)
+        {
+            // Instead of Timers what we could've used here is a cancellation token source based loop
+            // i.e. CancellationTokenSource.CancelAfter(TimeSpan) within a Task.Run(async delegate)
+            // They both seem to use internal TimerQueue. The difference is that Timer seem to
+            // lead to a relatively simpler implementation but the downside is callback is not
+            // async and unsubscribe call has to be fire-and-forget. On the other hand running
+            // CancellationTokenSource.CancelAfter in Task.Run(async delegate) gives us the
+            // chance to await the unsubscribe call but leaves us to deal with the created task.
+            // Since awaiting unsubscribe isn't crucial Timer approach is currently acceptable.
+            // If we need an async loop in the future cancellation token source approach can be used.
+            _idleTimeoutTimer = new Timer(_ => EndSubscription(NatsSubEndReason.IdleTimeout));
+        }
+
+        if (_timeout != default)
+        {
+            _timeoutTimer = new Timer(_ => EndSubscription(NatsSubEndReason.Timeout));
+        }
     }
 
+    /// <summary>
+    /// The subject name to subscribe to.
+    /// </summary>
     public string Subject { get; }
 
+    /// <summary>
+    /// If specified, the subscriber will join this queue group. Subscribers with the same queue group name,
+    /// become a queue group, and only one randomly chosen subscriber of the queue group will
+    /// consume a message each time a message is received by the queue group.
+    /// </summary>
     public string? QueueGroup { get; }
 
-    public int Sid { get; }
+    // Hide from public API using explicit interface implementations
+    // since INatsSub is marked as internal.
+    int? INatsSub.PendingMsgs => _pendingMsgs == -1 ? null : Volatile.Read(ref _pendingMsgs);
 
-    internal NatsConnection Connection { get; }
+    int INatsSub.Sid => _sid;
 
-    internal SubscriptionManager Manager { get; }
+    internal NatsSubEndReason EndReason => (NatsSubEndReason)Volatile.Read(ref _endReasonRaw);
 
-    public virtual ValueTask DisposeAsync()
+    protected NatsConnection Connection { get; }
+
+    void INatsSub.Ready()
     {
-        return Manager.RemoveAsync(Sid);
+        _idleTimeoutTimer?.Change(_idleTimeout, Timeout.InfiniteTimeSpan);
+        _timeoutTimer?.Change(dueTime: _timeout, period: Timeout.InfiniteTimeSpan);
     }
 
-    public abstract ValueTask ReceiveAsync(string subject, string? replyTo, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer);
+    /// <summary>
+    /// Complete the message channel, stop timers if they were used and send an unsubscribe
+    /// message to the server.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> that represents the asynchronous server UNSUB operation.</returns>
+    public ValueTask UnsubscribeAsync()
+    {
+        lock (this)
+        {
+            if (_unsubscribed)
+                return ValueTask.CompletedTask;
+            _unsubscribed = true;
+        }
+
+        _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        TryComplete();
+
+        return _manager.RemoveAsync(_sid);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (this)
+        {
+            if (_disposed)
+                return ValueTask.CompletedTask;
+            _disposed = true;
+        }
+
+        GC.SuppressFinalize(this);
+
+        _timeoutTimer?.Dispose();
+        _idleTimeoutTimer?.Dispose();
+
+        return UnsubscribeAsync();
+    }
+
+    ValueTask INatsSub.ReceiveAsync(
+        string subject,
+        string? replyTo,
+        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> payloadBuffer) =>
+        ReceiveInternalAsync(subject, replyTo, headersBuffer, payloadBuffer);
+
+    protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
+
+    protected void ResetIdleTimeout()
+    {
+        _idleTimeoutTimer?.Change(dueTime: _idleTimeout, period: Timeout.InfiniteTimeSpan);
+    }
+
+    protected void DecrementMaxMsgs()
+    {
+        if (!_countPendingMsgs) return;
+        var maxMsgs = Interlocked.Decrement(ref _pendingMsgs);
+        if (maxMsgs == 0)
+            EndSubscription(NatsSubEndReason.MaxMsgs);
+    }
+
+    protected abstract void TryComplete();
+
+    private void EndSubscription(NatsSubEndReason reason)
+    {
+        lock (this)
+        {
+            if (_endSubscription)
+                return;
+            _endSubscription = true;
+        }
+
+        Interlocked.Exchange(ref _endReasonRaw, (int)reason);
+
+        // Stops timers and completes channel writer to exit any message iterators
+        // synchronously, which is fine, however, we're not able to wait for
+        // UNSUB message to be sent to the server. If any message arrives after this point
+        // channel writer will ignore the message and we would effectively drop it.
+        var fireAndForget = UnsubscribeAsync();
+    }
 }
 
 public sealed class NatsSub : NatsSubBase
@@ -42,21 +179,17 @@ public sealed class NatsSub : NatsSubBase
         AllowSynchronousContinuations = false,
     });
 
-    internal NatsSub(NatsConnection connection, SubscriptionManager manager, string subject, string? queueGroup, int sid)
-        : base(connection, manager, subject, queueGroup, sid)
+    internal NatsSub(NatsConnection connection, SubscriptionManager manager, string subject, NatsSubOpts? opts, int sid)
+        : base(connection, manager, subject, opts, sid)
     {
     }
 
     public ChannelReader<NatsMsg> Msgs => _msgs.Reader;
 
-    public override ValueTask DisposeAsync()
+    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
-        _msgs.Writer.TryComplete();
-        return base.DisposeAsync();
-    }
+        ResetIdleTimeout();
 
-    public override ValueTask ReceiveAsync(string subject, string? replyTo, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
-    {
         var natsMsg = NatsMsg.Build(
             subject,
             replyTo,
@@ -65,8 +198,12 @@ public sealed class NatsSub : NatsSubBase
             Connection,
             Connection.HeaderParser);
 
-        return _msgs.Writer.WriteAsync(natsMsg);
+        await _msgs.Writer.WriteAsync(natsMsg).ConfigureAwait(false);
+
+        DecrementMaxMsgs();
     }
+
+    protected override void TryComplete() => _msgs.Writer.TryComplete();
 }
 
 public sealed class NatsSub<T> : NatsSubBase
@@ -79,21 +216,17 @@ public sealed class NatsSub<T> : NatsSubBase
         AllowSynchronousContinuations = false,
     });
 
-    internal NatsSub(NatsConnection connection, SubscriptionManager manager, string subject, string? queueGroup, int sid, INatsSerializer serializer)
-        : base(connection, manager, subject, queueGroup, sid) => Serializer = serializer;
+    internal NatsSub(NatsConnection connection, SubscriptionManager manager, string subject, NatsSubOpts? opts, int sid, INatsSerializer serializer)
+        : base(connection, manager, subject, opts, sid) => Serializer = serializer;
 
     public ChannelReader<NatsMsg<T>> Msgs => _msgs.Reader;
 
     private INatsSerializer Serializer { get; }
 
-    public override ValueTask DisposeAsync()
+    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
-        _msgs.Writer.TryComplete();
-        return base.DisposeAsync();
-    }
+        ResetIdleTimeout();
 
-    public override ValueTask ReceiveAsync(string subject, string? replyTo, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
-    {
         var natsMsg = NatsMsg<T>.Build(
             subject,
             replyTo,
@@ -103,6 +236,10 @@ public sealed class NatsSub<T> : NatsSubBase
             Connection.HeaderParser,
             Serializer);
 
-        return _msgs.Writer.WriteAsync(natsMsg);
+        await _msgs.Writer.WriteAsync(natsMsg).ConfigureAwait(false);
+
+        DecrementMaxMsgs();
     }
+
+    protected override void TryComplete() => _msgs.Writer.TryComplete();
 }

--- a/src/NATS.Client.Core/NatsSubOpts.cs
+++ b/src/NATS.Client.Core/NatsSubOpts.cs
@@ -2,7 +2,39 @@ namespace NATS.Client.Core;
 
 public readonly record struct NatsSubOpts
 {
+    /// <summary>
+    /// If specified, the subscriber will join this queue group. Subscribers with the same queue group name,
+    /// become a queue group, and only one randomly chosen subscriber of the queue group will
+    /// consume a message each time a message is received by the queue group.
+    /// </summary>
     public string? QueueGroup { get; init; }
 
+    /// <summary>
+    /// Serializer to use to deserialize the message if a model is being used.
+    /// If not set, serializer set in connection options or the default JSON serializer
+    /// will be used.
+    /// </summary>
     public INatsSerializer? Serializer { get; init; }
+
+    /// <summary>
+    /// Number of messages to wait for before automatically unsubscribing.
+    /// If not set, all published messages will be received until explicitly
+    /// unsubscribed or disposed.
+    /// </summary>
+    public int? MaxMsgs { get; init; }
+
+    /// <summary>
+    /// Amount of time to wait before automatically unsubscribing.
+    /// If not set, all published messages will be received until explicitly
+    /// unsubscribed or disposed.
+    /// </summary>
+    public TimeSpan? Timeout { get; init; }
+
+    /// <summary>
+    /// Maximum amount of time allowed between any two subsequent messages
+    /// before automatically unsubscribing.
+    /// If not set, all published messages will be received until explicitly
+    /// unsubscribed or disposed.
+    /// </summary>
+    public TimeSpan? IdleTimeout { get; init; }
 }

--- a/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
+++ b/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
@@ -16,7 +16,7 @@ public class LowLevelApiTest
         var nats = server.CreateClientConnection();
 
         var builder = new NatsSubCustomTestBuilder(_output);
-        NatsSubTest sub = await nats.SubAsync<NatsSubTest>("foo.*", null, builder);
+        NatsSubTest sub = await nats.SubAsync<NatsSubTest>("foo.*", opts: default, builder);
 
         await Retry.Until(
             "subscription is ready",
@@ -54,11 +54,17 @@ public class LowLevelApiTest
 
         public string QueueGroup => string.Empty;
 
+        public int? PendingMsgs => 0;
+
         public int Sid => 0;
+
+        public void Ready()
+        {
+        }
 
         public ValueTask DisposeAsync() => _manager.DisposeAsync();
 
-        public ValueTask ReceiveAsync(string subject, string? replyTo, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
+        public ValueTask ReceiveAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
         {
             if (subject.EndsWith(".sync"))
             {
@@ -113,9 +119,9 @@ public class LowLevelApiTest
             }
         }
 
-        public NatsSubTest Build(string subject, string? queueGroup, NatsConnection connection, SubscriptionManager manager)
+        public NatsSubTest Build(string subject, NatsSubOpts? opts, NatsConnection connection, SubscriptionManager manager)
         {
-            return new NatsSubTest(this, _output, manager);
+            return new NatsSubTest(builder: this, _output, manager);
         }
 
         public void Sync() => Interlocked.Exchange(ref _sync, 1);

--- a/tests/NATS.Client.Core.Tests/ProtocolTest.cs
+++ b/tests/NATS.Client.Core.Tests/ProtocolTest.cs
@@ -218,6 +218,8 @@ public class ProtocolTest
                 await nats.PublishAsync("foo2", i);
             }
 
+            await Retry.Until("all pub frames arrived", () => proxy.Frames.Count(f => f.Message.StartsWith("PUB foo2")) == 100);
+
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             var cancellationToken = cts.Token;
             var count = 0;

--- a/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
+++ b/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
@@ -119,23 +119,23 @@ public class SubscriptionTest
                 count++;
             }
 
-            Assert.Equal(0, count);
             Assert.Equal(NatsSubEndReason.Timeout, sub.EndReason);
+            Assert.Equal(0, count);
         }
 
         // Auto unsubscribe on idle timeout
         {
             const string subject = "foo3";
-            var opts = new NatsSubOpts { IdleTimeout = TimeSpan.FromMilliseconds(500) };
+            var opts = new NatsSubOpts { IdleTimeout = TimeSpan.FromSeconds(2) };
 
             await using var sub = await nats.SubscribeAsync<int>(subject, opts);
 
             await nats.PublishAsync(subject, 0);
             await nats.PublishAsync(subject, 1);
             await nats.PublishAsync(subject, 2);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Task.Delay(TimeSpan.FromSeconds(.1));
             await nats.PublishAsync(subject, 3);
-            await Task.Delay(TimeSpan.FromMilliseconds(700));
+            await Task.Delay(TimeSpan.FromSeconds(2.1));
             await nats.PublishAsync(subject, 100);
 
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -147,8 +147,8 @@ public class SubscriptionTest
                 count++;
             }
 
-            Assert.Equal(4, count);
             Assert.Equal(NatsSubEndReason.IdleTimeout, sub.EndReason);
+            Assert.Equal(4, count);
         }
 
         // Manual unsubscribe

--- a/tests/NATS.Client.Core.Tests/_NatsServer.cs
+++ b/tests/NATS.Client.Core.Tests/_NatsServer.cs
@@ -310,10 +310,16 @@ public class NatsProxy : IDisposable
             while (true)
             {
                 var tcpClient1 = _tcpListener.AcceptTcpClient();
+                tcpClient1.NoDelay = true;
+                tcpClient1.ReceiveBufferSize = 0;
+                tcpClient1.SendBufferSize = 0;
 
                 var n = client++;
 
                 var tcpClient2 = new TcpClient("127.0.0.1", port);
+                tcpClient2.NoDelay = true;
+                tcpClient2.ReceiveBufferSize = 0;
+                tcpClient2.SendBufferSize = 0;
 
 #pragma warning disable CS4014
                 Task.Run(() =>

--- a/tests/NATS.Client.Core.Tests/_NatsServer.cs
+++ b/tests/NATS.Client.Core.Tests/_NatsServer.cs
@@ -296,30 +296,39 @@ public class NatsProxy : IDisposable
 {
     private readonly ITestOutputHelper _outputHelper;
     private readonly TcpListener _tcpListener;
+    private readonly List<TcpClient> _clients = new();
     private readonly List<Frame> _frames = new();
+    private readonly Stopwatch _watch = new();
 
     public NatsProxy(int port, ITestOutputHelper outputHelper)
     {
         _outputHelper = outputHelper;
         _tcpListener = new TcpListener(IPAddress.Loopback, 0);
         _tcpListener.Start();
+        _watch.Restart();
 
         Task.Run(() =>
         {
             var client = 0;
             while (true)
             {
-                var tcpClient1 = _tcpListener.AcceptTcpClient();
-                tcpClient1.NoDelay = true;
-                tcpClient1.ReceiveBufferSize = 0;
-                tcpClient1.SendBufferSize = 0;
+                TcpClient tcpClient1 = _tcpListener.AcceptTcpClient();
+                TcpClient tcpClient2;
+                lock (_clients)
+                {
+                    tcpClient1.NoDelay = true;
+                    tcpClient1.ReceiveBufferSize = 0;
+                    tcpClient1.SendBufferSize = 0;
+                    _clients.Add(tcpClient1);
+
+                    tcpClient2 = new TcpClient("127.0.0.1", port);
+                    tcpClient2.NoDelay = true;
+                    tcpClient2.ReceiveBufferSize = 0;
+                    tcpClient2.SendBufferSize = 0;
+                    _clients.Add(tcpClient2);
+                }
 
                 var n = client++;
-
-                var tcpClient2 = new TcpClient("127.0.0.1", port);
-                tcpClient2.NoDelay = true;
-                tcpClient2.ReceiveBufferSize = 0;
-                tcpClient2.SendBufferSize = 0;
 
 #pragma warning disable CS4014
                 Task.Run(() =>
@@ -366,6 +375,17 @@ public class NatsProxy : IDisposable
 
     public int Port => ((IPEndPoint)_tcpListener.Server.LocalEndPoint!).Port;
 
+    public IReadOnlyList<Frame> AllFrames
+    {
+        get
+        {
+            lock (_frames)
+            {
+                return _frames.ToList();
+            }
+        }
+    }
+
     public IReadOnlyList<Frame> Frames
     {
         get
@@ -382,6 +402,33 @@ public class NatsProxy : IDisposable
     public IReadOnlyList<Frame> ClientFrames => Frames.Where(f => f.Origin == "C").ToList();
 
     public IReadOnlyList<Frame> ServerFrames => Frames.Where(f => f.Origin == "S").ToList();
+
+    public void Reset()
+    {
+        lock (_clients)
+        {
+            foreach (var tcpClient in _clients)
+            {
+                try
+                {
+                    tcpClient.Close();
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+
+            ClearFrames();
+
+            _watch.Restart();
+        }
+    }
+
+    public void ClearFrames()
+    {
+        lock (_frames) _frames.Clear();
+    }
 
     public void Dispose() => _tcpListener.Server.Dispose();
 
@@ -402,7 +449,7 @@ public class NatsProxy : IDisposable
         if (Regex.IsMatch(message, @"^(INFO|CONNECT|PING|PONG|UNSUB|SUB|\+OK|-ERR)"))
         {
             if (client > 0)
-                AddFrame(new Frame(client, origin, message));
+                AddFrame(new Frame(_watch.Elapsed, client, origin, message));
 
             sw.WriteLine(message);
             sw.Flush();
@@ -448,13 +495,13 @@ public class NatsProxy : IDisposable
             sw.Flush();
 
             if (client > 0)
-                AddFrame(new Frame(client, origin, Message: $"{message}␍␊{sb}"));
+                AddFrame(new Frame(_watch.Elapsed, client, origin, Message: $"{message}␍␊{sb}"));
 
             return true;
         }
 
         if (client > 0)
-            AddFrame(new Frame(client, Origin: "ERROR", Message: $"Unknown protocol: {message}"));
+            AddFrame(new Frame(_watch.Elapsed, client, Origin: "ERROR", Message: $"Unknown protocol: {message}"));
 
         return false;
     }
@@ -467,7 +514,7 @@ public class NatsProxy : IDisposable
 
     private void Log(string text) => _outputHelper.WriteLine($"{DateTime.Now:HH:mm:ss.fff} [PROXY] {text}");
 
-    public record Frame(int Client, string Origin, string Message);
+    public record Frame(TimeSpan Timestamp, int Client, string Origin, string Message);
 }
 
 public class NullOutputHelper : ITestOutputHelper


### PR DESCRIPTION
* Auto-unsubscribe on max-msgs, timeout and idle timeout
* Pass NatsMsg by ref to reduce copy overhead
* Hidden internal INatsSub API from public API using explicit interface implementations