### PR TITLE
Have DLLs stamped with version too

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,8 @@
 
     <PropertyGroup>
         <!-- NuGet Packaging -->
-        <PackageVersion>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)..\version.txt"))</PackageVersion>
+        <Version>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)..\version.txt"))</Version>
+        <PackageVersion>$(Version)</PackageVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Company>CNCF</Company>
         <Authors>The NATS Authors</Authors>


### PR DESCRIPTION
Assigning `Version` property has the following effect on the DLL files, if the `version.txt` (hence NuGet version) was `2.0.0-alpha.0` for example:
* *File version* and *Assembly version*: `2.0.0.0`
* *Product version*: `2.0.0-alpha.0`