### PR TITLE
remove Sid from INatsSub

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;SA0001</NoWarn>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>

--- a/sandbox/BlazorWasm/Server/NatsServices/WeatherForecastService.cs
+++ b/sandbox/BlazorWasm/Server/NatsServices/WeatherForecastService.cs
@@ -45,13 +45,17 @@ public class WeatherForecastService : IHostedService, IAsyncDisposable
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Weather Forecast Services is stopping");
-        if (_replySubscription != null) await _replySubscription.UnsubscribeAsync();
-        if (_replyTask != null) await _replyTask;
+        if (_replySubscription != null)
+            await _replySubscription.UnsubscribeAsync();
+        if (_replyTask != null)
+            await _replyTask;
     }
 
     public async ValueTask DisposeAsync()
     {
-        if (_replySubscription != null) await _replySubscription.DisposeAsync();
-        if (_replyTask != null) await _replyTask;
+        if (_replySubscription != null)
+            await _replySubscription.DisposeAsync();
+        if (_replyTask != null)
+            await _replyTask;
     }
 }

--- a/sandbox/ConsoleApp/Program.cs
+++ b/sandbox/ConsoleApp/Program.cs
@@ -43,10 +43,10 @@ var subscription = await conn.SubscribeAsync<Person>("foo");
 
 _ = Task.Run(async () =>
 {
-        await foreach (var msg in subscription.Msgs.ReadAllAsync())
-        {
-            Console.WriteLine($"Received {msg.Data}");
-        }
+    await foreach (var msg in subscription.Msgs.ReadAllAsync())
+    {
+        Console.WriteLine($"Received {msg.Data}");
+    }
 });
 
 // publish

--- a/sandbox/Example.Core.PublishHeaders/Program.cs
+++ b/sandbox/Example.Core.PublishHeaders/Program.cs
@@ -1,4 +1,4 @@
-﻿// > nats sub bar.*
+// > nats sub bar.*
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 
@@ -9,7 +9,7 @@ Print("[CON] Connecting...\n");
 
 await using var connection = new NatsConnection(options);
 
-for (int i = 0; i < 10; i++)
+for (var i = 0; i < 10; i++)
 {
     Print($"[PUB] Publishing to subject ({i}) '{subject}'...\n");
     await connection.PublishAsync<Bar>(

--- a/sandbox/Example.Core.PublishModel/Program.cs
+++ b/sandbox/Example.Core.PublishModel/Program.cs
@@ -1,4 +1,4 @@
-﻿// > nats sub bar.*
+// > nats sub bar.*
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 
@@ -9,7 +9,7 @@ Print("[CON] Connecting...\n");
 
 await using var connection = new NatsConnection(options);
 
-for (int i = 0; i < 10; i++)
+for (var i = 0; i < 10; i++)
 {
     Print($"[PUB] Publishing to subject ({i}) '{subject}'...\n");
     await connection.PublishAsync<Bar>(subject, new Bar { Id = i, Name = "Baz" });

--- a/sandbox/Example.Core.SubscribeHeaders/Program.cs
+++ b/sandbox/Example.Core.SubscribeHeaders/Program.cs
@@ -1,4 +1,4 @@
-﻿// > nats pub bar.xyz --count=10 "my_message_{{ Count }}" -H X-Foo:Baz
+// > nats pub bar.xyz --count=10 "my_message_{{ Count }}" -H X-Foo:Baz
 
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -13,7 +13,7 @@ await using var connection = new NatsConnection(options);
 
 Print($"[SUB] Subscribing to subject '{subject}'...\n");
 
-NatsSub sub = await connection.SubscribeAsync(subject);
+var sub = await connection.SubscribeAsync(subject);
 
 await foreach (var msg in sub.Msgs.ReadAllAsync())
 {

--- a/sandbox/Example.Core.SubscribeModel/Program.cs
+++ b/sandbox/Example.Core.SubscribeModel/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 
 var subject = "bar.*";
@@ -10,7 +10,7 @@ await using var connection = new NatsConnection(options);
 
 Print($"[SUB] Subscribing to subject '{subject}'...\n");
 
-NatsSub<Bar> sub = await connection.SubscribeAsync<Bar>(subject);
+var sub = await connection.SubscribeAsync<Bar>(subject);
 
 await foreach (var msg in sub.Msgs.ReadAllAsync())
 {

--- a/sandbox/Example.Core.SubscribeQueueGroup/Program.cs
+++ b/sandbox/Example.Core.SubscribeQueueGroup/Program.cs
@@ -1,4 +1,4 @@
-﻿// > nats pub foo.xyz --count=10 "my_message_{{ Count }}"
+// > nats pub foo.xyz --count=10 "my_message_{{ Count }}"
 using System.Text;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
@@ -12,7 +12,7 @@ Print("[1][CON] Connecting...\n");
 await using var connection1 = new NatsConnection(options);
 
 Print($"[1][SUB] Subscribing to subject '{subject}'...\n");
-NatsSub sub1 = await connection1.SubscribeAsync(subject, new NatsSubOpts { QueueGroup = $"My-Workers" });
+var sub1 = await connection1.SubscribeAsync(subject, new NatsSubOpts { QueueGroup = $"My-Workers" });
 var task1 = Task.Run(async () =>
 {
     await foreach (var msg in sub1.Msgs.ReadAllAsync())
@@ -28,7 +28,7 @@ Print("[2][CON] Connecting...\n");
 await using var connection2 = new NatsConnection(options);
 
 Print($"[2][SUB] Subscribing to subject '{subject}'...\n");
-NatsSub sub2 = await connection2.SubscribeAsync(subject, new NatsSubOpts { QueueGroup = $"My-Workers" });
+var sub2 = await connection2.SubscribeAsync(subject, new NatsSubOpts { QueueGroup = $"My-Workers" });
 var task2 = Task.Run(async () =>
 {
     await foreach (var msg in sub2.Msgs.ReadAllAsync())

--- a/sandbox/Example.Core.SubscribeRaw/Program.cs
+++ b/sandbox/Example.Core.SubscribeRaw/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 
@@ -11,7 +11,7 @@ await using var connection = new NatsConnection(options);
 
 Print($"[SUB] Subscribing to subject '{subject}'...\n");
 
-NatsSub sub = await connection.SubscribeAsync(subject);
+var sub = await connection.SubscribeAsync(subject);
 
 await foreach (var msg in sub.Msgs.ReadAllAsync())
 {

--- a/sandbox/NatsBenchmark/Program.cs
+++ b/sandbox/NatsBenchmark/Program.cs
@@ -813,7 +813,8 @@ internal static class NatsMsgTestUtils
 {
     internal static NatsSub<T>? Register<T>(this NatsSub<T>? sub, Action<NatsMsg<T>> action)
     {
-        if (sub == null) return null;
+        if (sub == null)
+            return null;
         Task.Run(async () =>
         {
             await foreach (var natsMsg in sub.Msgs.ReadAllAsync())
@@ -826,7 +827,8 @@ internal static class NatsMsgTestUtils
 
     internal static NatsSub? Register(this NatsSub? sub, Action<NatsMsg> action)
     {
-        if (sub == null) return null;
+        if (sub == null)
+            return null;
         Task.Run(async () =>
         {
             await foreach (var natsMsg in sub.Msgs.ReadAllAsync())

--- a/src/NATS.Client.Core/Commands/CommandBase.cs
+++ b/src/NATS.Client.Core/Commands/CommandBase.cs
@@ -95,7 +95,8 @@ internal abstract class AsyncCommandBase<TSelf> : ICommand, IAsyncCommand, IObje
         _timerRegistration.Dispose();
         _timerRegistration = default;
 
-        if (IsCanceled) return; // already called Canceled, it invoked SetCanceled.
+        if (IsCanceled)
+            return; // already called Canceled, it invoked SetCanceled.
 
         if (_timer != null)
         {
@@ -113,7 +114,8 @@ internal abstract class AsyncCommandBase<TSelf> : ICommand, IAsyncCommand, IObje
 
     public void SetCanceled()
     {
-        if (_noReturn) return;
+        if (_noReturn)
+            return;
 
         _timerRegistration.Dispose();
         _timerRegistration = default;
@@ -134,7 +136,8 @@ internal abstract class AsyncCommandBase<TSelf> : ICommand, IAsyncCommand, IObje
 
     public void SetException(Exception exception)
     {
-        if (_noReturn) return;
+        if (_noReturn)
+            return;
 
         _timerRegistration.Dispose();
         _timerRegistration = default;
@@ -249,7 +252,8 @@ internal abstract class AsyncCommandBase<TSelf, TResponse> : ICommand, IAsyncCom
     {
         _response = result;
 
-        if (IsCanceled) return; // already called Canceled, it invoked SetCanceled.
+        if (IsCanceled)
+            return; // already called Canceled, it invoked SetCanceled.
 
         _timerRegistration.Dispose();
         _timerRegistration = default;
@@ -289,7 +293,8 @@ internal abstract class AsyncCommandBase<TSelf, TResponse> : ICommand, IAsyncCom
 
     public void SetException(Exception exception)
     {
-        if (_noReturn) return;
+        if (_noReturn)
+            return;
 
         _timerRegistration.Dispose();
         _timerRegistration = default;

--- a/src/NATS.Client.Core/Internal/BufferExtensions.cs
+++ b/src/NATS.Client.Core/Internal/BufferExtensions.cs
@@ -29,7 +29,7 @@ internal static class BufferExtensions
     {
         if (source.IsSingleSegment)
         {
-            int index = source.First.Span.IndexOfAny(value0, value1);
+            var index = source.First.Span.IndexOfAny(value0, value1);
             if (index != -1)
             {
                 return source.GetPosition(index);
@@ -46,11 +46,11 @@ internal static class BufferExtensions
     private static SequencePosition? PositionOfAnyMultiSegment<T>(in ReadOnlySequence<T> source, T value0, T value1)
         where T : IEquatable<T>
     {
-        SequencePosition position = source.Start;
-        SequencePosition result = position;
-        while (source.TryGet(ref position, out ReadOnlyMemory<T> memory))
+        var position = source.Start;
+        var result = position;
+        while (source.TryGet(ref position, out var memory))
         {
-            int index = memory.Span.IndexOfAny(value0, value1);
+            var index = memory.Span.IndexOfAny(value0, value1);
             if (index != -1)
             {
                 return source.GetPosition(index, result);

--- a/src/NATS.Client.Core/Internal/INatsSub.cs
+++ b/src/NATS.Client.Core/Internal/INatsSub.cs
@@ -11,8 +11,6 @@ internal interface INatsSub : IAsyncDisposable
 
     int? PendingMsgs { get; }
 
-    int Sid { get; }
-
     /// <summary>
     /// Called after subscription is sent to the server.
     /// Helps maintain more accurate timeouts, especially idle timeout.
@@ -34,8 +32,7 @@ internal class NatsSubBuilder : INatsSubBuilder<NatsSub>
 
     public NatsSub Build(string subject, NatsSubOpts? opts, NatsConnection connection, SubscriptionManager manager)
     {
-        var sid = manager.GetNextSid();
-        return new NatsSub(connection, manager, subject, opts, sid);
+        return new NatsSub(connection, manager, subject, opts);
     }
 }
 
@@ -51,7 +48,6 @@ internal class NatsSubModelBuilder<T> : INatsSubBuilder<NatsSub<T>>
 
     public NatsSub<T> Build(string subject, NatsSubOpts? opts, NatsConnection connection, SubscriptionManager manager)
     {
-        var sid = manager.GetNextSid();
-        return new NatsSub<T>(connection, manager, subject, opts, sid, _serializer);
+        return new NatsSub<T>(connection, manager, subject, opts, _serializer);
     }
 }

--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -102,9 +102,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
         // skip `INFO`
         var jsonReader = new Utf8JsonReader(buffer.Slice(5));
 
-        var serverInfo = JsonSerializer.Deserialize<ServerInfo>(ref jsonReader);
-        if (serverInfo == null)
-            throw new NatsException("Can not parse ServerInfo.");
+        var serverInfo = JsonSerializer.Deserialize<ServerInfo>(ref jsonReader) ?? throw new NatsException("Can not parse ServerInfo.");
         return serverInfo;
     }
 

--- a/src/NATS.Client.Core/Internal/StringExtensions.cs
+++ b/src/NATS.Client.Core/Internal/StringExtensions.cs
@@ -11,7 +11,7 @@ internal static class StringExtensions
     public static void WriteASCIIBytes(this string key, Span<byte> span)
     {
         var count = Math.Min(key.Length, span.Length);
-        for (int i = 0; i < count; i++)
+        for (var i = 0; i < count; i++)
         {
             int c = key[i];
             span[i] = (byte)c;

--- a/src/NATS.Client.Core/Internal/SubscriptionManager.cs
+++ b/src/NATS.Client.Core/Internal/SubscriptionManager.cs
@@ -48,8 +48,7 @@ internal sealed class SubscriptionManager : ISubscriptionManager, IAsyncDisposab
         }
     }
 
-    public async ValueTask<T> SubscribeAsync<T>(string subject, NatsSubOpts? opts, T sub,
-        CancellationToken cancellationToken)
+    public async ValueTask<T> SubscribeAsync<T>(string subject, NatsSubOpts? opts, T sub, CancellationToken cancellationToken)
         where T : INatsSub
     {
         var sid = GetNextSid();
@@ -73,10 +72,7 @@ internal sealed class SubscriptionManager : ISubscriptionManager, IAsyncDisposab
         }
     }
 
-    protected int GetNextSid() => Interlocked.Increment(ref _sid);
-
-    public ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid,
-        in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
+    public ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
     {
         int? orphanSid = null;
         lock (_gate)
@@ -147,6 +143,8 @@ internal sealed class SubscriptionManager : ISubscriptionManager, IAsyncDisposab
 
         return _connection.UnsubscribeAsync(subMetadata.Sid);
     }
+
+    private int GetNextSid() => Interlocked.Increment(ref _sid);
 
     private async Task CleanupAsync()
     {

--- a/src/NATS.Client.Core/Internal/SubscriptionManager.cs
+++ b/src/NATS.Client.Core/Internal/SubscriptionManager.cs
@@ -1,15 +1,24 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 
 namespace NATS.Client.Core.Internal;
 
-internal sealed class SubscriptionManager : IAsyncDisposable
+internal interface ISubscriptionManager
+{
+    public ValueTask RemoveAsync(INatsSub sub);
+}
+
+internal sealed record SubscriptionMetadata(int Sid);
+
+internal sealed class SubscriptionManager : ISubscriptionManager, IAsyncDisposable
 {
     private readonly ILogger<SubscriptionManager> _logger;
     private readonly object _gate = new();
     private readonly NatsConnection _connection;
     private readonly ConcurrentDictionary<int, WeakReference<INatsSub>> _bySid = new();
+    private readonly ConditionalWeakTable<INatsSub, SubscriptionMetadata> _bySub = new();
     private readonly CancellationTokenSource _cts;
     private readonly Task _timer;
     private readonly TimeSpan _cleanupInterval;
@@ -29,29 +38,31 @@ internal sealed class SubscriptionManager : IAsyncDisposable
     {
         lock (_gate)
         {
-            foreach (var subRef in _bySid.Values)
+            foreach (var subRef in _bySid)
             {
-                if (subRef.TryGetTarget(out var sub))
+                if (subRef.Value.TryGetTarget(out var sub))
                 {
-                    yield return (sub.Sid, sub.Subject, sub.QueueGroup, sub.PendingMsgs);
+                    yield return (subRef.Key, sub.Subject, sub.QueueGroup, sub.PendingMsgs);
                 }
             }
         }
     }
 
-    public int GetNextSid() => Interlocked.Increment(ref _sid);
-
-    public async ValueTask<T> SubscribeAsync<T>(string subject, NatsSubOpts? opts, T sub, CancellationToken cancellationToken)
+    public async ValueTask<T> SubscribeAsync<T>(string subject, NatsSubOpts? opts, T sub,
+        CancellationToken cancellationToken)
         where T : INatsSub
     {
+        var sid = GetNextSid();
         lock (_gate)
         {
-            _bySid[sub.Sid] = new WeakReference<INatsSub>(sub);
+            _bySid[sid] = new WeakReference<INatsSub>(sub);
+            _bySub.AddOrUpdate(sub, new SubscriptionMetadata(Sid: sid));
         }
 
         try
         {
-            await _connection.SubscribeCoreAsync(sub.Sid, subject, opts?.QueueGroup, opts?.MaxMsgs, cancellationToken).ConfigureAwait(false);
+            await _connection.SubscribeCoreAsync(sid, subject, opts?.QueueGroup, opts?.MaxMsgs, cancellationToken)
+                .ConfigureAwait(false);
             sub.Ready();
             return sub;
         }
@@ -62,7 +73,10 @@ internal sealed class SubscriptionManager : IAsyncDisposable
         }
     }
 
-    public ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
+    protected int GetNextSid() => Interlocked.Increment(ref _sid);
+
+    public ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid,
+        in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
     {
         int? orphanSid = null;
         lock (_gate)
@@ -118,11 +132,20 @@ internal sealed class SubscriptionManager : IAsyncDisposable
         }
     }
 
-    public ValueTask RemoveAsync(int sid)
+    public ValueTask RemoveAsync(INatsSub sub)
     {
+        if (!_bySub.TryGetValue(sub, out var subMetadata))
+        {
+            throw new NatsException("subscription is not registered with the manager");
+        }
+
         lock (_gate)
-            _bySid.Remove(sid, out _);
-        return _connection.UnsubscribeAsync(sid);
+        {
+            _bySub.Remove(sub);
+            _bySid.Remove(subMetadata.Sid, out _);
+        }
+
+        return _connection.UnsubscribeAsync(subMetadata.Sid);
     }
 
     private async Task CleanupAsync()

--- a/src/NATS.Client.Core/NatsConnection.Util.cs
+++ b/src/NATS.Client.Core/NatsConnection.Util.cs
@@ -1,4 +1,4 @@
-﻿using NATS.Client.Core.Commands;
+using NATS.Client.Core.Commands;
 using NATS.Client.Core.Internal;
 
 namespace NATS.Client.Core;

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -578,7 +578,7 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
 
     private async ValueTask EnqueueCommandAsync(ICommand command)
     {
-        RETRY:
+    RETRY:
         if (_commandWriter.TryWrite(command))
         {
             Interlocked.Increment(ref Counter.PendingMessages);

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -130,8 +130,7 @@ public abstract class NatsSubBase : INatsSub
         ReadOnlySequence<byte> payloadBuffer) =>
         ReceiveInternalAsync(subject, replyTo, headersBuffer, payloadBuffer);
 
-    protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
+    protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
 
     protected void ResetIdleTimeout()
     {
@@ -185,8 +184,7 @@ public sealed class NatsSub : NatsSubBase
 
     public ChannelReader<NatsMsg> Msgs => _msgs.Reader;
 
-    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
         ResetIdleTimeout();
 
@@ -224,8 +222,7 @@ public sealed class NatsSub<T> : NatsSubBase
 
     private INatsSerializer Serializer { get; }
 
-    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
         ResetIdleTimeout();
 

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -14,8 +14,7 @@ internal enum NatsSubEndReason
 
 public abstract class NatsSubBase : INatsSub
 {
-    private readonly int _sid;
-    private readonly SubscriptionManager _manager;
+    private readonly ISubscriptionManager _manager;
     private readonly Timer? _timeoutTimer;
     private readonly Timer? _idleTimeoutTimer;
     private readonly TimeSpan _idleTimeout;
@@ -27,9 +26,8 @@ public abstract class NatsSubBase : INatsSub
     private int _endReasonRaw;
     private int _pendingMsgs;
 
-    internal NatsSubBase(NatsConnection connection, SubscriptionManager manager, string subject, NatsSubOpts? opts, int sid)
+    internal NatsSubBase(NatsConnection connection, ISubscriptionManager manager, string subject, NatsSubOpts? opts)
     {
-        _sid = sid;
         _manager = manager;
         _pendingMsgs = opts is { MaxMsgs: > 0 } ? opts.Value.MaxMsgs ?? -1 : -1;
         _countPendingMsgs = _pendingMsgs > 0;
@@ -77,8 +75,6 @@ public abstract class NatsSubBase : INatsSub
     // since INatsSub is marked as internal.
     int? INatsSub.PendingMsgs => _pendingMsgs == -1 ? null : Volatile.Read(ref _pendingMsgs);
 
-    int INatsSub.Sid => _sid;
-
     internal NatsSubEndReason EndReason => (NatsSubEndReason)Volatile.Read(ref _endReasonRaw);
 
     protected NatsConnection Connection { get; }
@@ -107,7 +103,7 @@ public abstract class NatsSubBase : INatsSub
         _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
         TryComplete();
 
-        return _manager.RemoveAsync(_sid);
+        return _manager.RemoveAsync(this);
     }
 
     public ValueTask DisposeAsync()
@@ -134,7 +130,8 @@ public abstract class NatsSubBase : INatsSub
         ReadOnlySequence<byte> payloadBuffer) =>
         ReceiveInternalAsync(subject, replyTo, headersBuffer, payloadBuffer);
 
-    protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
+    protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo,
+        ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
 
     protected void ResetIdleTimeout()
     {
@@ -143,7 +140,8 @@ public abstract class NatsSubBase : INatsSub
 
     protected void DecrementMaxMsgs()
     {
-        if (!_countPendingMsgs) return;
+        if (!_countPendingMsgs)
+            return;
         var maxMsgs = Interlocked.Decrement(ref _pendingMsgs);
         if (maxMsgs == 0)
             EndSubscription(NatsSubEndReason.MaxMsgs);
@@ -180,14 +178,15 @@ public sealed class NatsSub : NatsSubBase
         AllowSynchronousContinuations = false,
     });
 
-    internal NatsSub(NatsConnection connection, SubscriptionManager manager, string subject, NatsSubOpts? opts, int sid)
-        : base(connection, manager, subject, opts, sid)
+    internal NatsSub(NatsConnection connection, ISubscriptionManager manager, string subject, NatsSubOpts? opts)
+        : base(connection, manager, subject, opts)
     {
     }
 
     public ChannelReader<NatsMsg> Msgs => _msgs.Reader;
 
-    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo,
+        ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
         ResetIdleTimeout();
 
@@ -209,22 +208,24 @@ public sealed class NatsSub : NatsSubBase
 
 public sealed class NatsSub<T> : NatsSubBase
 {
-    private readonly Channel<NatsMsg<T>> _msgs = Channel.CreateBounded<NatsMsg<T>>(new BoundedChannelOptions(capacity: 1_000)
-    {
-        FullMode = BoundedChannelFullMode.Wait,
-        SingleWriter = true,
-        SingleReader = false,
-        AllowSynchronousContinuations = false,
-    });
+    private readonly Channel<NatsMsg<T>> _msgs = Channel.CreateBounded<NatsMsg<T>>(
+        new BoundedChannelOptions(capacity: 1_000)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleWriter = true,
+            SingleReader = false,
+            AllowSynchronousContinuations = false,
+        });
 
-    internal NatsSub(NatsConnection connection, SubscriptionManager manager, string subject, NatsSubOpts? opts, int sid, INatsSerializer serializer)
-        : base(connection, manager, subject, opts, sid) => Serializer = serializer;
+    internal NatsSub(NatsConnection connection, ISubscriptionManager manager, string subject, NatsSubOpts? opts, INatsSerializer serializer)
+        : base(connection, manager, subject, opts) => Serializer = serializer;
 
     public ChannelReader<NatsMsg<T>> Msgs => _msgs.Reader;
 
     private INatsSerializer Serializer { get; }
 
-    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo,
+        ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
         ResetIdleTimeout();
 

--- a/tests/NATS.Client.Core.Tests/CancellationTest.cs
+++ b/tests/NATS.Client.Core.Tests/CancellationTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace NATS.Client.Core.Tests;
 

--- a/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
+++ b/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
@@ -16,14 +16,14 @@ public class LowLevelApiTest
         var nats = server.CreateClientConnection();
 
         var builder = new NatsSubCustomTestBuilder(_output);
-        NatsSubTest sub = await nats.SubAsync<NatsSubTest>("foo.*", opts: default, builder);
+        var sub = await nats.SubAsync<NatsSubTest>("foo.*", opts: default, builder);
 
         await Retry.Until(
             "subscription is ready",
             () => builder.IsSynced,
             async () => await nats.PubAsync("foo.sync"));
 
-        for (int i = 0; i < 10; i++)
+        for (var i = 0; i < 10; i++)
         {
             var headers = new NatsHeaders { { "X-Test", $"value-{i}" } };
             await nats.PubModelAsync<int>($"foo.data{i}", i, JsonNatsSerializer.Default, "bar", headers);
@@ -76,8 +76,8 @@ public class LowLevelApiTest
             }
             else
             {
-                byte[]? headers = headersBuffer?.ToArray();
-                byte[] payload = payloadBuffer.ToArray();
+                var headers = headersBuffer?.ToArray();
+                var payload = payloadBuffer.ToArray();
 
                 var sb = new StringBuilder();
                 sb.AppendLine($"Subject: {subject}");
@@ -130,7 +130,8 @@ public class LowLevelApiTest
 
         public void MessageReceived(string message)
         {
-            lock (_messages) _messages.Add(message);
+            lock (_messages)
+                _messages.Add(message);
         }
     }
 }

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.QueueGroups.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.QueueGroups.cs
@@ -36,9 +36,11 @@ public abstract partial class NatsConnectionTest
                     }
 
                     Assert.Equal($"foo.xyz{msg.Data}", msg.Subject);
-                    lock (messages1) messages1.Add(msg.Data);
+                    lock (messages1)
+                        messages1.Add(msg.Data);
                     var total = Interlocked.Increment(ref count);
-                    if (total == messageCount) cts.Cancel();
+                    if (total == messageCount)
+                        cts.Cancel();
                 }
             },
             cts.Token);
@@ -57,9 +59,11 @@ public abstract partial class NatsConnectionTest
                     }
 
                     Assert.Equal($"foo.xyz{msg.Data}", msg.Subject);
-                    lock (messages2) messages2.Add(msg.Data);
+                    lock (messages2)
+                        messages2.Add(msg.Data);
                     var total = Interlocked.Increment(ref count);
-                    if (total == messageCount) cts.Cancel();
+                    if (total == messageCount)
+                        cts.Cancel();
                 }
             },
             cts.Token);
@@ -69,7 +73,7 @@ public abstract partial class NatsConnectionTest
             () => Volatile.Read(ref sync1) + Volatile.Read(ref sync2) == 2,
             async () => await conn3.PublishAsync("foo.sync", 0));
 
-        for (int i = 0; i < messageCount; i++)
+        for (var i = 0; i < messageCount; i++)
         {
             await conn3.PublishAsync($"foo.xyz{i}", i);
         }
@@ -100,7 +104,7 @@ public abstract partial class NatsConnectionTest
         // Ensure we received all messages from the two subscribers.
         messages.Sort();
         Assert.Equal(messageCount, messages.Count);
-        for (int i = 0; i < messageCount; i++)
+        for (var i = 0; i < messageCount; i++)
         {
             var data = messages[i];
             Assert.Equal(i, data);

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -114,7 +114,7 @@ public abstract partial class NatsConnectionTest
             if (m.Data < 10)
             {
                 Interlocked.Exchange(ref sync, m.Data);
-                await m.ReplyAsync( "sync");
+                await m.ReplyAsync("sync");
             }
 
             if (m.Data == 100)

--- a/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
@@ -14,7 +14,7 @@ public class RequestReplyTest
             await msg.ReplyAsync(msg.Data * 2);
         });
 
-        for (int i = 0; i < 10; i++)
+        for (var i = 0; i < 10; i++)
         {
             var rep = await nats.RequestAsync<int, int>("foo", i);
             Assert.Equal(i * 2, rep);

--- a/tests/NATS.Client.Core.Tests/_NatsServer.cs
+++ b/tests/NATS.Client.Core.Tests/_NatsServer.cs
@@ -313,7 +313,7 @@ public class NatsProxy : IDisposable
             var client = 0;
             while (true)
             {
-                TcpClient tcpClient1 = _tcpListener.AcceptTcpClient();
+                var tcpClient1 = _tcpListener.AcceptTcpClient();
                 TcpClient tcpClient2;
                 lock (_clients)
                 {
@@ -420,7 +420,8 @@ public class NatsProxy : IDisposable
                 }
             }
 
-            lock (_frames) _frames.Clear();
+            lock (_frames)
+                _frames.Clear();
 
             _watch.Restart();
         }
@@ -436,7 +437,8 @@ public class NatsProxy : IDisposable
             "flush sync frame",
             () => AllFrames.Any(f => f.Message == $"PUB {subject} 0␍␊"));
 
-        lock (_frames) _frames.Clear();
+        lock (_frames)
+            _frames.Clear();
     }
 
     public void Dispose() => _tcpListener.Server.Dispose();
@@ -453,7 +455,8 @@ public class NatsProxy : IDisposable
             return false;
         }
 
-        if (message == null) return false;
+        if (message == null)
+            return false;
 
         if (Regex.IsMatch(message, @"^(INFO|CONNECT|PING|PONG|UNSUB|SUB|\+OK|-ERR)"))
         {
@@ -474,8 +477,10 @@ public class NatsProxy : IDisposable
             while (true)
             {
                 var read = sr.Read(span);
-                if (read == 0) break;
-                if (read == -1) return false;
+                if (read == 0)
+                    break;
+                if (read == -1)
+                    return false;
                 span = span[read..];
             }
 
@@ -518,7 +523,8 @@ public class NatsProxy : IDisposable
     private void AddFrame(Frame frame)
     {
         // Log($"Dump {frame}");
-        lock (_frames) _frames.Add(frame);
+        lock (_frames)
+            _frames.Add(frame);
     }
 
     private void Log(string text) => _outputHelper.WriteLine($"{DateTime.Now:HH:mm:ss.fff} [PROXY] {text}");

--- a/tests/NATS.Client.Core.Tests/_Utils.cs
+++ b/tests/NATS.Client.Core.Tests/_Utils.cs
@@ -48,7 +48,8 @@ internal static class NatsMsgTestUtils
 {
     internal static Task Register<T>(this NatsSub<T>? sub, Action<NatsMsg<T>> action)
     {
-        if (sub == null) return Task.CompletedTask;
+        if (sub == null)
+            return Task.CompletedTask;
         return Task.Run(async () =>
         {
             await foreach (var natsMsg in sub.Msgs.ReadAllAsync())
@@ -60,7 +61,8 @@ internal static class NatsMsgTestUtils
 
     internal static Task Register<T>(this NatsSub<T>? sub, Func<NatsMsg<T>, Task> action)
     {
-        if (sub == null) return Task.CompletedTask;
+        if (sub == null)
+            return Task.CompletedTask;
         return Task.Run(async () =>
         {
             await foreach (var natsMsg in sub.Msgs.ReadAllAsync())
@@ -72,7 +74,8 @@ internal static class NatsMsgTestUtils
 
     internal static Task Register(this NatsSub? sub, Action<NatsMsg> action)
     {
-        if (sub == null) return Task.CompletedTask;
+        if (sub == null)
+            return Task.CompletedTask;
         return Task.Run(async () =>
         {
             await foreach (var natsMsg in sub.Msgs.ReadAllAsync())
@@ -84,7 +87,8 @@ internal static class NatsMsgTestUtils
 
     internal static Task Register(this NatsSub? sub, Func<NatsMsg, Task> action)
     {
-        if (sub == null) return Task.CompletedTask;
+        if (sub == null)
+            return Task.CompletedTask;
         return Task.Run(async () =>
         {
             await foreach (var natsMsg in sub.Msgs.ReadAllAsync())


### PR DESCRIPTION
Rough draft - `dotnet format` touched a bunch of files so sorry for the confusing diff

Removes `Sid` from `INatsSub`.  Also introduces `ISubscriptionManager`

`Sid` is an implementation detail of the default subscription manager.  For muxed subscriptions, such as `InboxSubscription`, an `InboxSubscriptionManager` could be used instead. 