### PR TITLE
Allow Configuration of Subscription Channels

### DIFF
--- a/src/NATS.Client.Core/NatsSubChannelOpts.cs
+++ b/src/NATS.Client.Core/NatsSubChannelOpts.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Channels;
+
+namespace NATS.Client.Core;
+
+/// <summary>
+/// Options For setting the FullMode and Capacity for a the <see cref="Channel"/> created for Subscriptions
+/// </summary>
+public readonly record struct NatsSubChannelOpts
+{
+    /// <summary>
+    /// The Behavior of the Subscription's Channel when the Capacity has been reached.
+    /// By default, the behavior is <seealso cref="BoundedChannelFullMode.Wait"/>
+    /// </summary>
+    public BoundedChannelFullMode? FullMode { get; init; }
+
+    /// <summary>
+    /// The Maximum Capacity for the channel. If not specified, a default of 1000 is used.
+    /// </summary>
+    public int? Capacity { get; init; }
+}

--- a/src/NATS.Client.Core/NatsSubOpts.cs
+++ b/src/NATS.Client.Core/NatsSubOpts.cs
@@ -1,3 +1,5 @@
+using System.Threading.Channels;
+
 namespace NATS.Client.Core;
 
 public readonly record struct NatsSubOpts
@@ -65,4 +67,9 @@ public readonly record struct NatsSubOpts
     /// server subscription request.
     /// </summary>
     public bool? CanBeCancelled { get; init; }
+
+    /// <summary>
+    /// Allows Configuration of <see cref="Channel"/> options for a subscription
+    /// </summary>
+    public NatsSubChannelOpts? ChannelOptions { get; init; }
 }


### PR DESCRIPTION
There is value in being able to configure the `BoundedChannelOptions` for a given subscription (or series of subscriptions.)

For example, in cases where it is preferred to discard older data on a subscription, or cases where _only_ the most recent value is the one that is desired.

This PR also has the benefit, in the default case, we can just re-use our internal `BoundedChannelOptions` rather than passing a new one every time a new subscription is created (i.e. less memory allocation.)

Note that for the sake of reuse, this marked `internal static` on `NatsSub` rather than `private static`, since to have a separate static readonly on `NatsSub<T>` would both be unnecessary and would cause a new static to be allocated for every new `T` on `NatsSub<T>`.