### PR TITLE
Inbox subscription iprovements

### DIFF
--- a/src/NATS.Client.Core/NatsRequestExtensions.cs
+++ b/src/NATS.Client.Core/NatsRequestExtensions.cs
@@ -6,6 +6,12 @@ namespace NATS.Client.Core;
 public static class NatsRequestExtensions
 {
     /// <summary>
+    /// Create a new inbox subject with the form {Inbox Prefix}.{Unique Connection ID}.{Unique Inbox ID}
+    /// </summary>
+    /// <returns>A <see cref="string"/> containing a unique inbox subject.</returns>
+    public static string NewInbox(this NatsConnection nats) => $"{nats.InboxPrefix}{Guid.NewGuid():n}";
+
+    /// <summary>
     /// Request and receive a single reply from a responder.
     /// </summary>
     /// <param name="nats">NATS connection</param>


### PR DESCRIPTION
- Extension method to generate an Inbox - `nats.NewInbox()`
- Inbox Subscription manager support multiple Subscriptions on the same Inbox Subject
- Use `ConditionalWeakTable` to improve GC
  - No cleanup/logging when Inbox Subs are GC'd without Disposal, but it doesn't really matter since there is no Unsub right now

I'm a little rusty on how to update ConcurrentDictionary with a value of another collection - check my implementation there.  Open to suggestions if there's a better pattern