### PR TITLE
JetStream basic usage

### DIFF
--- a/src/NATS.Client.JetStream/Internal/JSErrorAwareJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/Internal/JSErrorAwareJsonSerializer.cs
@@ -1,0 +1,42 @@
+﻿using System.Buffers;
+using System.Text.Json;
+using NATS.Client.Core;
+using NATS.Client.JetStream.Models;
+
+namespace NATS.Client.JetStream.Internal;
+
+internal sealed class JSErrorAwareJsonSerializer : INatsSerializer
+{
+    public static readonly JSErrorAwareJsonSerializer Default = new();
+
+    public int Serialize<T>(ICountableBufferWriter bufferWriter, T? value) =>
+        throw new NotSupportedException();
+
+    public T? Deserialize<T>(in ReadOnlySequence<byte> buffer)
+    {
+        // We need to determine what type we're deserializing into
+        // .NET 6 new APIs to the rescue: we can read the buffer once
+        // by deserializing into a document, inspect and using the new
+        // API deserialize to the final type from the document.
+        var jsonDocument = JsonDocument.Parse(buffer);
+        if (jsonDocument.RootElement.TryGetProperty("error", out var errorElement))
+        {
+            var error = errorElement.Deserialize<ApiError>();
+            if (error == null)
+                throw new NatsJetStreamException("Can't parse JetStream error JSON payload");
+            throw new JSErrorException(error);
+        }
+
+        return jsonDocument.Deserialize<T>();
+    }
+
+    public object? Deserialize(in ReadOnlySequence<byte> buffer, Type type) =>
+        throw new NotSupportedException();
+}
+
+internal class JSErrorException : Exception
+{
+    public JSErrorException(ApiError error) => Error = error;
+
+    public ApiError Error { get; }
+}

--- a/src/NATS.Client.JetStream/JSContext.cs
+++ b/src/NATS.Client.JetStream/JSContext.cs
@@ -1,5 +1,11 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using NATS.Client.Core;
+using NATS.Client.Core.Internal;
+using NATS.Client.JetStream.Internal;
 using NATS.Client.JetStream.Models;
 
 namespace NATS.Client.JetStream;
@@ -15,23 +21,158 @@ public class JSContext
         _options = options;
     }
 
-    public async ValueTask<JSStream> CreateStream(Action<StreamCreateRequest> request)
+    public ValueTask<JSResponse<StreamInfo>> CreateStreamAsync(
+        StreamConfiguration request,
+        CancellationToken cancellationToken = default) =>
+        JSRequestAsync<StreamConfiguration, StreamInfo>(
+            subject: $"{_options.Prefix}.STREAM.CREATE.{request.Name}",
+            request,
+            cancellationToken);
+
+    public ValueTask<JSResponse<StreamMsgDeleteResponse>> DeleteStreamAsync(
+        string stream,
+        CancellationToken cancellationToken = default) =>
+        JSRequestAsync<object, StreamMsgDeleteResponse>(
+            subject: $"{_options.Prefix}.STREAM.DELETE.{stream}",
+            null,
+            cancellationToken);
+
+    public ValueTask<JSResponse<ConsumerInfo>> CreateConsumerAsync(
+        ConsumerCreateRequest request,
+        CancellationToken cancellationToken = default) =>
+        JSRequestAsync<ConsumerCreateRequest, ConsumerInfo>(
+            subject: $"{_options.Prefix}.CONSUMER.CREATE.{request.StreamName}.{request.Config.Name}",
+            request,
+            cancellationToken);
+
+    public async ValueTask<PubAckResponse> PublishAsync<T>(
+        string subject,
+        T? data,
+        NatsPubOpts opts = default,
+        CancellationToken cancellationToken = default)
     {
-        var requestObj = new StreamCreateRequest();
-        request(requestObj);
+        await using var sub = await _nats.RequestSubAsync<T, PubAckResponse>(
+                subject: subject,
+                data: data,
+                requestOpts: opts,
+                replyOpts: default,
+                cancellationToken)
+            .ConfigureAwait(false);
 
-        Validator.ValidateObject(requestObj, new ValidationContext(requestObj));
+        if (await sub.Msgs.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            if (sub.Msgs.TryRead(out var msg))
+            {
+                if (msg.Data == null)
+                {
+                    throw new NatsJetStreamException("No response data received");
+                }
 
-        var response =
-            await _nats.RequestAsync<StreamCreateRequest, StreamCreateResponse>(
-                $"{_options.Prefix}.STREAM.CREATE.{requestObj.Name}",
-                requestObj);
+                return msg.Data;
+            }
+        }
 
-        // TODO: Better error handling
-        if (response?.Data == null)
-            throw new NatsJetStreamException("No response received");
+        if (sub.EndReason == NatsSubEndReason.Cancelled)
+        {
+            throw new OperationCanceledException("Publishing inbox subscription was cancelled");
+        }
 
-        return new JSStream(response.Value.Data);
+        if (sub is { EndReason: NatsSubEndReason.Exception, Exception: not null })
+        {
+            throw sub.Exception;
+        }
+
+        throw new NatsJetStreamException("No response received");
+    }
+
+    public async IAsyncEnumerable<NatsMsg> ConsumeAsync(
+        string stream,
+        string consumer,
+        ConsumerGetnextRequest request,
+        NatsSubOpts requestOpts = default,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var inbox = $"_INBOX.{Guid.NewGuid():n}";
+
+        await using var sub = await _nats.SubAsync(
+            subject: inbox,
+            opts: requestOpts,
+            builder: NatsSubBuilder.Default,
+            cancellationToken);
+
+        await _nats.PubModelAsync(
+            subject: $"$JS.API.CONSUMER.MSG.NEXT.{stream}.{consumer}",
+            data: request,
+            serializer: JsonNatsSerializer.Default,
+            replyTo: inbox,
+            headers: default,
+            cancellationToken);
+
+        await foreach (var msg in sub.Msgs.ReadAllAsync(CancellationToken.None))
+        {
+            yield return msg;
+        }
+
+        if (sub.EndReason == NatsSubEndReason.Cancelled)
+        {
+            throw new OperationCanceledException("Consumer's inbox subscription was cancelled");
+        }
+
+        if (sub is { EndReason: NatsSubEndReason.Exception, Exception: not null })
+        {
+            throw sub.Exception;
+        }
+    }
+
+    internal async ValueTask<JSResponse<TResponse>> JSRequestAsync<TRequest, TResponse>(
+        string subject,
+        TRequest? request,
+        CancellationToken cancellationToken = default)
+        where TRequest : class
+        where TResponse : class
+    {
+        if (request != null)
+        {
+            Validator.ValidateObject(request, new ValidationContext(request));
+        }
+
+        await using var sub = await _nats.RequestSubAsync<TRequest, TResponse>(
+                subject: subject,
+                data: request,
+                requestOpts: default,
+                replyOpts: new NatsSubOpts { Serializer = JSErrorAwareJsonSerializer.Default },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (await sub.Msgs.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            if (sub.Msgs.TryRead(out var msg))
+            {
+                if (msg.Data == null)
+                {
+                    throw new NatsJetStreamException("No response data received");
+                }
+
+                return new JSResponse<TResponse>(msg.Data, default);
+            }
+        }
+
+        if (sub.EndReason == NatsSubEndReason.Cancelled)
+        {
+            throw new OperationCanceledException("Request's inbox subscription was cancelled");
+        }
+
+        if (sub is { EndReason: NatsSubEndReason.Exception, Exception: not null })
+        {
+            if (sub.Exception is NatsSubException { InnerException: JSErrorException jsError })
+            {
+                return new JSResponse<TResponse>(default, jsError.Error);
+            }
+
+            throw sub.Exception;
+        }
+
+        throw new NatsJetStreamException("No response received");
     }
 }
 
@@ -51,14 +192,4 @@ public class NatsJetStreamException : NatsException
 public record JSOptions
 {
     public string Prefix { get; init; } = "$JS.API";
-}
-
-public class JSStream
-{
-    public JSStream(StreamCreateResponse response)
-    {
-        Response = response;
-    }
-
-    public StreamCreateResponse Response { get; }
 }

--- a/src/NATS.Client.JetStream/JSResponse.cs
+++ b/src/NATS.Client.JetStream/JSResponse.cs
@@ -1,0 +1,22 @@
+﻿using NATS.Client.JetStream.Models;
+
+namespace NATS.Client.JetStream;
+
+/// <summary>
+/// JetStream response including an optional error property encapsulating both successful and failed calls.
+/// </summary>
+/// <typeparam name="T">JetStream response type</typeparam>
+public readonly struct JSResponse<T>
+{
+    internal JSResponse(T? response, ApiError? error)
+    {
+        Response = response;
+        Error = error;
+    }
+
+    public T? Response { get; }
+
+    public ApiError? Error { get; }
+
+    public bool Success => Error == null && Response != null;
+}

--- a/src/NATS.Client.JetStream/Models/ConsumerConfiguration.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfiguration.cs
@@ -52,7 +52,7 @@ public record ConsumerConfiguration
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public ConsumerConfigurationAckPolicy AckPolicy { get; set; } = NATS.Client.JetStream.Models.ConsumerConfigurationAckPolicy.None;
+    public ConsumerConfigurationAckPolicy AckPolicy { get; set; } = ConsumerConfigurationAckPolicy.none;
 
     /// <summary>
     /// How long (in nanoseconds) to allow messages to remain un-acknowledged before attempting redelivery
@@ -88,7 +88,7 @@ public record ConsumerConfiguration
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public ConsumerConfigurationReplayPolicy ReplayPolicy { get; set; } = NATS.Client.JetStream.Models.ConsumerConfigurationReplayPolicy.Instant;
+    public ConsumerConfigurationReplayPolicy ReplayPolicy { get; set; } = NATS.Client.JetStream.Models.ConsumerConfigurationReplayPolicy.instant;
 
     [System.Text.Json.Serialization.JsonPropertyName("sample_freq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigurationAckPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigurationAckPolicy.cs
@@ -1,13 +1,15 @@
 namespace NATS.Client.JetStream.Models;
 
+// TODO: enum member naming with JSON serialization isn't working for some reason
+#pragma warning disable SA1300
 public enum ConsumerConfigurationAckPolicy
 {
     [System.Runtime.Serialization.EnumMember(Value = @"none")]
-    None = 0,
+    none = 0,
 
     [System.Runtime.Serialization.EnumMember(Value = @"all")]
-    All = 1,
+    all = 1,
 
     [System.Runtime.Serialization.EnumMember(Value = @"explicit")]
-    Explicit = 2,
+    @explicit = 2,
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigurationDeliverPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigurationDeliverPolicy.cs
@@ -1,22 +1,24 @@
 namespace NATS.Client.JetStream.Models;
 
+// TODO: enum member naming with JSON serialization isn't working for some reason
+#pragma warning disable SA1300
 public enum ConsumerConfigurationDeliverPolicy
 {
     [System.Runtime.Serialization.EnumMember(Value = @"all")]
-    All = 0,
+    all = 0,
 
     [System.Runtime.Serialization.EnumMember(Value = @"last")]
-    Last = 1,
+    last = 1,
 
     [System.Runtime.Serialization.EnumMember(Value = @"new")]
-    New = 2,
+    @new = 2,
 
     [System.Runtime.Serialization.EnumMember(Value = @"by_start_sequence")]
-    ByStartSequence = 3,
+    by_start_sequence = 3,
 
     [System.Runtime.Serialization.EnumMember(Value = @"by_start_time")]
-    ByStartTime = 4,
+    by_start_time = 4,
 
     [System.Runtime.Serialization.EnumMember(Value = @"last_per_subject")]
-    LastPerSubject = 5,
+    last_per_subject = 5,
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigurationReplayPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigurationReplayPolicy.cs
@@ -1,10 +1,12 @@
 namespace NATS.Client.JetStream.Models;
 
+// TODO: enum member naming with JSON serialization isn't working for some reason
+#pragma warning disable SA1300
 public enum ConsumerConfigurationReplayPolicy
 {
     [System.Runtime.Serialization.EnumMember(Value = @"instant")]
-    Instant = 0,
+    instant = 0,
 
     [System.Runtime.Serialization.EnumMember(Value = @"original")]
-    Original = 1,
+    original = 1,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfiguration.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfiguration.cs
@@ -40,7 +40,7 @@ public record StreamConfiguration
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public StreamConfigurationRetention Retention { get; set; } = NATS.Client.JetStream.Models.StreamConfigurationRetention.Limits;
+    public StreamConfigurationRetention Retention { get; set; } = NATS.Client.JetStream.Models.StreamConfigurationRetention.limits;
 
     /// <summary>
     /// How many Consumers can be defined for a given Stream. -1 for unlimited.
@@ -97,7 +97,7 @@ public record StreamConfiguration
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public StreamConfigurationStorage Storage { get; set; } = NATS.Client.JetStream.Models.StreamConfigurationStorage.File;
+    public StreamConfigurationStorage Storage { get; set; } = StreamConfigurationStorage.file;
 
     /// <summary>
     /// Optional compression algorithm used for the Stream.
@@ -105,7 +105,7 @@ public record StreamConfiguration
     [System.Text.Json.Serialization.JsonPropertyName("compression")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public StreamConfigurationCompression Compression { get; set; } = NATS.Client.JetStream.Models.StreamConfigurationCompression.None;
+    public StreamConfigurationCompression Compression { get; set; } = NATS.Client.JetStream.Models.StreamConfigurationCompression.none;
 
     /// <summary>
     /// How many replicas to keep for each message.
@@ -135,7 +135,7 @@ public record StreamConfiguration
     [System.Text.Json.Serialization.JsonPropertyName("discard")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-    public StreamConfigurationDiscard Discard { get; set; } = NATS.Client.JetStream.Models.StreamConfigurationDiscard.Old;
+    public StreamConfigurationDiscard Discard { get; set; } = StreamConfigurationDiscard.old;
 
     /// <summary>
     /// The time window to track duplicate messages for, expressed in nanoseconds. 0 for default

--- a/src/NATS.Client.JetStream/Models/StreamConfigurationCompression.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigurationCompression.cs
@@ -1,10 +1,12 @@
 namespace NATS.Client.JetStream.Models;
 
+// TODO: enum member naming with JSON serialization isn't working for some reason
+#pragma warning disable SA1300
 public enum StreamConfigurationCompression
 {
     [System.Runtime.Serialization.EnumMember(Value = @"none")]
-    None = 0,
+    none = 0,
 
     [System.Runtime.Serialization.EnumMember(Value = @"s2")]
-    S2 = 1,
+    s2 = 1,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigurationDiscard.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigurationDiscard.cs
@@ -1,10 +1,12 @@
 namespace NATS.Client.JetStream.Models;
 
+// TODO: enum member naming with JSON serialization isn't working for some reason
+#pragma warning disable SA1300
 public enum StreamConfigurationDiscard
 {
     [System.Runtime.Serialization.EnumMember(Value = @"old")]
-    Old = 0,
+    old = 0,
 
     [System.Runtime.Serialization.EnumMember(Value = @"new")]
-    New = 1,
+    @new = 1,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigurationRetention.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigurationRetention.cs
@@ -1,13 +1,15 @@
 namespace NATS.Client.JetStream.Models;
 
+// TODO: enum member naming with JSON serialization isn't working for some reason
+#pragma warning disable SA1300
 public enum StreamConfigurationRetention
 {
     [System.Runtime.Serialization.EnumMember(Value = @"limits")]
-    Limits = 0,
+    limits = 0,
 
     [System.Runtime.Serialization.EnumMember(Value = @"interest")]
-    Interest = 1,
+    interest = 1,
 
     [System.Runtime.Serialization.EnumMember(Value = @"workqueue")]
-    Workqueue = 2,
+    workqueue = 2,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigurationStorage.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigurationStorage.cs
@@ -1,10 +1,12 @@
 namespace NATS.Client.JetStream.Models;
 
+// TODO: enum member naming with JSON serialization isn't working for some reason
+#pragma warning disable SA1300
 public enum StreamConfigurationStorage
 {
     [System.Runtime.Serialization.EnumMember(Value = @"file")]
-    File = 0,
+    file = 0,
 
     [System.Runtime.Serialization.EnumMember(Value = @"memory")]
-    Memory = 1,
+    memory = 1,
 }

--- a/src/NATS.Client.JetStream/Models/StreamCreateResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamCreateResponse.cs
@@ -1,9 +1,12 @@
+using System.Text.Json;
+using NATS.Client.Core;
+using NATS.Client.Core.Internal;
+
 namespace NATS.Client.JetStream.Models;
 
 /// <summary>
 /// A response from the JetStream $JS.API.STREAM.CREATE API
 /// </summary>
-
 public record StreamCreateResponse : StreamInfo
 {
 }

--- a/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Buffers;
+using System.Text;
+using Microsoft.Extensions.Logging;
 using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
 
 namespace NATS.Client.Core.Tests;
 
@@ -13,39 +16,155 @@ public class JetStreamTest
     public async Task Create_stream_test()
     {
         await using var server = new NatsServer(new NullOutputHelper(), new NatsServerOptionsBuilder().UseTransport(TransportType.Tcp).UseJetStream().Build());
-        await using var nats = server.CreateClientConnection();
+        var nats = server.CreateClientConnection();
 
-        // Create stream
+        // Happy user
         {
             var context = new JSContext(nats, new JSOptions());
-            var stream = await context.CreateStream(request: stream =>
+
+            // Create stream
+            var response = await context.CreateStreamAsync(request: new StreamConfiguration
             {
-                stream.Name = "events";
-                stream.Subjects = new[] { "events" };
+                Name = "events", Subjects = new[] { "events.*" },
             });
-            _output.WriteLine($"RCV: {stream.Response}");
+            Assert.True(response.Success);
+            Assert.Null(response.Error);
+            Assert.NotNull(response.Response);
+            Assert.Equal("events", response.Response.Config.Name);
+
+            // Create consumer
+            var consumerInfo = await context.CreateConsumerAsync(new ConsumerCreateRequest
+            {
+                StreamName = "events",
+                Config = new ConsumerConfiguration
+                {
+                    Name = "consumer1",
+                    DurableName = "consumer1",
+
+                    // Turn on ACK so we can test them below
+                    AckPolicy = ConsumerConfigurationAckPolicy.@explicit,
+
+                    // Effectively set message expiry for the consumer
+                    // so that unacknowledged messages can be put back into
+                    // the consumer to be delivered again (in a sense).
+                    // This is to make below consumer tests work.
+                    AckWait = 2_000_000_000, // 2 seconds
+                },
+            });
+            Assert.True(consumerInfo.Success);
+            Assert.Null(consumerInfo.Error);
+            Assert.NotNull(consumerInfo.Response);
+            Assert.Equal("events", consumerInfo.Response.StreamName);
+            Assert.Equal("consumer1", consumerInfo.Response.Config.Name);
+
+            // Publish
+            PubAckResponse ack;
+            ack = await context.PublishAsync("events.foo", new TestData { Test = 1 });
+            Assert.Null(ack.Error);
+            Assert.Equal("events", ack.Stream);
+            Assert.Equal(1, ack.Seq);
+            Assert.False(ack.Duplicate);
+
+            // Message ID
+            ack = await context.PublishAsync("events.foo", new TestData { Test = 2 }, new NatsPubOpts
+            {
+                Headers = new NatsHeaders { { "Nats-Msg-Id", "test2" } },
+            });
+            Assert.Null(ack.Error);
+            Assert.Equal("events", ack.Stream);
+            Assert.Equal(2, ack.Seq);
+            Assert.False(ack.Duplicate);
+
+            // Duplicate
+            ack = await context.PublishAsync("events.foo", new TestData { Test = 2 }, new NatsPubOpts
+            {
+                Headers = new NatsHeaders { { "Nats-Msg-Id", "test2" } },
+            });
+            Assert.Null(ack.Error);
+            Assert.Equal("events", ack.Stream);
+            Assert.Equal(2, ack.Seq);
+            Assert.True(ack.Duplicate);
+
+            // Consume
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var messages = new List<NatsMsg>();
+            await foreach (var msg in context.ConsumeAsync(
+                               stream: "events",
+                               consumer: "consumer1",
+                               request: new ConsumerGetnextRequest { Batch = 100 },
+                               requestOpts: new NatsSubOpts { CanBeCancelled = true },
+                               cancellationToken: cts.Token))
+            {
+                messages.Add(msg);
+
+                // Only ACK one message so we can consume again
+                if (messages.Count == 1)
+                {
+                    await msg.ReplyAsync(new ReadOnlySequence<byte>("+ACK"u8.ToArray()), cancellationToken: cts.Token);
+                }
+
+                if (messages.Count == 2)
+                {
+                    break;
+                }
+            }
+
+            Assert.Equal(2, messages.Count);
+            Assert.Equal("events.foo", messages[0].Subject);
+            Assert.Equal("events.foo", messages[1].Subject);
+
+            // Consume the unacknowledged message
+            await foreach (var msg in context.ConsumeAsync(
+                               stream: "events",
+                               consumer: "consumer1",
+                               request: new ConsumerGetnextRequest { Batch = 100 },
+                               requestOpts: new NatsSubOpts { CanBeCancelled = true },
+                               cancellationToken: cts.Token))
+            {
+                Assert.Equal("events.foo", msg.Subject);
+                break;
+            }
         }
 
-        // Handle exceptions
+        // Handle errors
         {
             var context = new JSContext(nats, new JSOptions());
-            try
+
+            var response = await context.CreateStreamAsync(request: new StreamConfiguration
             {
-                var stream = await context.CreateStream(request: stream =>
-                {
-                    stream.Name = "events";
-                    stream.Subjects = new[] { "events" };
-                });
-                _output.WriteLine($"RCV: {stream.Response}");
-            }
-            catch (NatsSubException e)
-            {
-                var payload = e.Payload.Dump();
-                var headers = e.Headers.Dump();
-                _output.WriteLine($"{e}");
-                _output.WriteLine($"headers: {headers}");
-                _output.WriteLine($"payload: {payload}");
-            }
+                Name = "events2", Subjects = new[] { "events.*" },
+            });
+            Assert.False(response.Success);
+            Assert.Null(response.Response);
+            Assert.NotNull(response.Error);
+            Assert.Equal(400, response.Error.Code);
+
+            // subjects overlap with an existing stream
+            Assert.Equal(10065, response.Error.ErrCode);
+        }
+
+        // Delete stream
+        {
+            var context = new JSContext(nats, new JSOptions());
+            JSResponse<StreamMsgDeleteResponse> response;
+
+            // Success
+            response = await context.DeleteStreamAsync("events");
+            Assert.True(response.Success);
+            Assert.True(response.Response!.Success);
+
+            // Error
+            response = await context.DeleteStreamAsync("events2");
+            Assert.False(response.Success);
+            Assert.Equal(404, response.Error!.Code);
+
+            // stream not found
+            Assert.Equal(10059, response.Error!.ErrCode);
         }
     }
+}
+
+public class TestData
+{
+    public int Test { get; set; }
 }

--- a/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
+++ b/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
@@ -4,8 +4,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="ProcessX" Version="1.5.4" />
@@ -21,9 +23,9 @@
     <Using Include="NATS.Client.Core.Internal" />
     <Using Include="NATS.Client.Core.Commands" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\NATS.Client.Core\NATS.Client.Core.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/tests/NATS.Client.TestUtilities/NatsServerOptions.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServerOptions.cs
@@ -116,6 +116,8 @@ public sealed class NatsServerOptions : IDisposable
 
     public bool EnableJetStream { get; init; }
 
+    public string? JetStreamStoreDir { get; set; }
+
     public bool ServerDisposeReturnsPorts { get; init; } = true;
 
     public string? TlsClientCertFile { get; init; }
@@ -190,9 +192,7 @@ public sealed class NatsServerOptions : IDisposable
             if (EnableJetStream)
             {
                 sb.AppendLine("jetstream {");
-                var storeDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n"));
-                Directory.CreateDirectory(storeDir);
-                sb.AppendLine($"  store_dir: '{storeDir}'");
+                sb.AppendLine($"  store_dir: '{JetStreamStoreDir}'");
                 sb.AppendLine("}");
             }
 


### PR DESCRIPTION
Basic use case APIs, publish and consume methods implemented. Consider this as the 'low-level' JetStream API where we can build our more familiar NATS Client Simplified JetStream API.