### PR TITLE
Enable async for test wait signals

### DIFF
--- a/tests/NATS.Client.TestUtilities/WaitSignal.cs
+++ b/tests/NATS.Client.TestUtilities/WaitSignal.cs
@@ -56,7 +56,7 @@ public class WaitSignal
     {
         _timeout = timeout;
         _count = count;
-        _tcs = new TaskCompletionSource();
+        _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     public TimeSpan Timeout => _timeout;
@@ -106,7 +106,7 @@ public class WaitSignal<T>
     {
         _timeout = timeout;
         _count = count;
-        _tcs = new TaskCompletionSource<T>();
+        _tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     public TimeSpan Timeout => _timeout;


### PR DESCRIPTION
Make TaskCompletionSource used in wait signals run completions asynchronously to avoid potential deadlocks during test runs.

Note that this PR doesn't have any effect on the tests. It's not solving any current issues. It's just a precautionary fix for potential issues in general.