### PR TITLE
consistent Nats class prefix

### DIFF
--- a/src/NATS.Client.Core/INatsServerInfo.cs
+++ b/src/NATS.Client.Core/INatsServerInfo.cs
@@ -1,6 +1,6 @@
 namespace NATS.Client.Core;
 
-public interface IServerInfo
+public interface INatsServerInfo
 {
     string Id { get; }
 

--- a/src/NATS.Client.Core/Internal/ClientOpts.cs
+++ b/src/NATS.Client.Core/Internal/ClientOpts.cs
@@ -40,7 +40,7 @@ internal sealed class ClientOpts
     public bool TLSRequired { get; init; }
 
     [JsonPropertyName("nkey")]
-    public string? Nkey { get; set; }
+    public string? NKey { get; set; }
 
     /// <summary>The JWT that identifies a user permissions and account.</summary>
     [JsonPropertyName("jwt")]

--- a/src/NATS.Client.Core/Internal/ServerInfo.cs
+++ b/src/NATS.Client.Core/Internal/ServerInfo.cs
@@ -4,7 +4,7 @@ namespace NATS.Client.Core.Internal;
 
 // Defined from `type Info struct` in nats-server
 // https://github.com/nats-io/nats-server/blob/a23b1b7/server/server.go#L61
-internal sealed record ServerInfo : IServerInfo
+internal sealed record ServerInfo : INatsServerInfo
 {
     [JsonPropertyName("server_id")]
     public string Id { get; set; } = string.Empty;

--- a/src/NATS.Client.Core/Internal/UserCredentials.cs
+++ b/src/NATS.Client.Core/Internal/UserCredentials.cs
@@ -9,7 +9,7 @@ internal class UserCredentials
     {
         Jwt = authOpts.Jwt;
         Seed = authOpts.Seed;
-        Nkey = authOpts.Nkey;
+        NKey = authOpts.NKey;
         Token = authOpts.Token;
 
         if (!string.IsNullOrEmpty(authOpts.CredsFile))
@@ -19,7 +19,7 @@ internal class UserCredentials
 
         if (!string.IsNullOrEmpty(authOpts.NKeyFile))
         {
-            (Seed, Nkey) = LoadNKeyFile(authOpts.NKeyFile);
+            (Seed, NKey) = LoadNKeyFile(authOpts.NKeyFile);
         }
     }
 
@@ -27,7 +27,7 @@ internal class UserCredentials
 
     public string? Seed { get; }
 
-    public string? Nkey { get; }
+    public string? NKey { get; }
 
     public string? Token { get; }
 
@@ -36,7 +36,7 @@ internal class UserCredentials
         if (Seed == null || nonce == null)
             return null;
 
-        using var kp = Nkeys.FromSeed(Seed);
+        using var kp = NKeys.FromSeed(Seed);
         var bytes = kp.Sign(Encoding.ASCII.GetBytes(nonce));
         var sig = CryptoBytes.ToBase64String(bytes);
 
@@ -46,7 +46,7 @@ internal class UserCredentials
     internal void Authenticate(ClientOpts opts, ServerInfo? info)
     {
         opts.JWT = Jwt;
-        opts.Nkey = Nkey;
+        opts.NKey = NKey;
         opts.AuthToken = Token;
         opts.Sig = info is { AuthRequired: true, Nonce: { } } ? Sign(info.Nonce) : null;
     }

--- a/src/NATS.Client.Core/NKeyPair.cs
+++ b/src/NATS.Client.Core/NKeyPair.cs
@@ -7,7 +7,7 @@ namespace NATS.Client.Core;
 /// Partial implementation of the NATS Ed25519 KeyPair.  This is not complete, but provides enough
 /// functionality to implement the client side NATS 2.0 security scheme.
 /// </summary>
-public class NkeyPair : IDisposable
+public class NKeyPair : IDisposable
 {
     private byte[] _seed;
     private byte[] _expandedPrivateKey;
@@ -15,7 +15,7 @@ public class NkeyPair : IDisposable
 
     private bool _disposedValue = false; // To detect redundant calls
 
-    internal NkeyPair(byte[] userSeed)
+    internal NKeyPair(byte[] userSeed)
     {
         if (userSeed == null)
             throw new NatsException("seed cannot be null");
@@ -50,8 +50,8 @@ public class NkeyPair : IDisposable
     /// </summary>
     public void Wipe()
     {
-        Nkeys.Wipe(ref _seed);
-        Nkeys.Wipe(ref _expandedPrivateKey);
+        NKeys.Wipe(ref _seed);
+        NKeys.Wipe(ref _expandedPrivateKey);
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ public class NkeyPair : IDisposable
     }
 
     /// <summary>
-    /// Releases all resources used by the NkeyPair.
+    /// Releases all resources used by the NKeyPair.
     /// </summary>
     public void Dispose()
     {
@@ -75,7 +75,7 @@ public class NkeyPair : IDisposable
     }
 
     /// <summary>
-    /// Releases the unmanaged resources used by the NkeyPair and optionally releases the managed resources.
+    /// Releases the unmanaged resources used by the NKeyPair and optionally releases the managed resources.
     /// </summary>
     /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
     protected virtual void Dispose(bool disposing)
@@ -93,9 +93,9 @@ public class NkeyPair : IDisposable
 }
 
 /// <summary>
-/// Nkeys is a class provided to manipulate Nkeys and generate NkeyPairs.
+/// NKeys is a class provided to manipulate NKeys and generate NKeyPairs.
 /// </summary>
-public class Nkeys
+public class NKeys
 {
     // PrefixByteSeed is the version byte used for encoded NATS Seeds
     private const byte PrefixByteSeed = 18 << 3; // Base32-encodes to 'S...'
@@ -124,7 +124,7 @@ public class Nkeys
     /// <summary>
     /// Decodes a base 32 encoded NKey into a nkey seed and verifies the checksum.
     /// </summary>
-    /// <param name="src">Base 32 encoded Nkey.</param>
+    /// <param name="src">Base 32 encoded NKey.</param>
     /// <returns></returns>
     public static byte[] Decode(string src)
     {
@@ -163,16 +163,16 @@ public class Nkeys
     }
 
     /// <summary>
-    /// Creates an NkeyPair from a private seed String.
+    /// Creates an NKeyPair from a private seed String.
     /// </summary>
     /// <param name="seed"></param>
     /// <returns>A NATS Ed25519 Keypair</returns>
-    public static NkeyPair FromSeed(string seed)
+    public static NKeyPair FromSeed(string seed)
     {
         var userSeed = DecodeSeed(seed);
         try
         {
-            var kp = new NkeyPair(userSeed);
+            var kp = new NKeyPair(userSeed);
             return kp;
         }
         finally
@@ -215,7 +215,7 @@ public class Nkeys
     /// <returns>A the public key corresponding to Seed</returns>
     public static string PublicKeyFromSeed(string seed)
     {
-        var s = Nkeys.Decode(seed);
+        var s = NKeys.Decode(seed);
         if ((s[0] & (31 << 3)) != PrefixByteSeed)
         {
             throw new NatsException("Not a seed");
@@ -258,7 +258,7 @@ public class Nkeys
 
     internal static byte[] DecodeSeed(string src)
     {
-        return DecodeSeed(Nkeys.Decode(src));
+        return DecodeSeed(NKeys.Decode(src));
     }
 
     internal static string Encode(byte prefixbyte, bool seed, byte[] src)

--- a/src/NATS.Client.Core/NatsAuthOpts.cs
+++ b/src/NATS.Client.Core/NatsAuthOpts.cs
@@ -12,7 +12,7 @@ public record NatsAuthOpts
 
     public string? Jwt { get; init; }
 
-    public string? Nkey { get; init; }
+    public string? NKey { get; init; }
 
     public string? Seed { get; init; }
 

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -72,7 +72,7 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
         SubscriptionManager = new SubscriptionManager(this, InboxPrefix);
         _logger = opts.LoggerFactory.CreateLogger<NatsConnection>();
         _clientOpts = ClientOpts.Create(Opts);
-        HeaderParser = new HeaderParser(opts.HeaderEncoding);
+        HeaderParser = new NatsHeaderParser(opts.HeaderEncoding);
     }
 
     // events
@@ -86,9 +86,9 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
 
     public NatsConnectionState ConnectionState { get; private set; }
 
-    public IServerInfo? ServerInfo => WritableServerInfo; // server info is set when received INFO
+    public INatsServerInfo? ServerInfo => WritableServerInfo; // server info is set when received INFO
 
-    public HeaderParser HeaderParser { get; }
+    public NatsHeaderParser HeaderParser { get; }
 
     internal SubscriptionManager SubscriptionManager { get; }
 

--- a/src/NATS.Client.Core/NatsHeaderParser.cs
+++ b/src/NATS.Client.Core/NatsHeaderParser.cs
@@ -12,7 +12,7 @@ using NATS.Client.Core.Internal;
 // ReSharper disable PossiblyImpureMethodCallOnReadonlyVariable
 namespace NATS.Client.Core;
 
-public class HeaderParser
+public class NatsHeaderParser
 {
     private const byte ByteCR = (byte)'\r';
     private const byte ByteLF = (byte)'\n';
@@ -23,7 +23,7 @@ public class HeaderParser
 
     private readonly Encoding _encoding;
 
-    public HeaderParser(Encoding encoding) => _encoding = encoding;
+    public NatsHeaderParser(Encoding encoding) => _encoding = encoding;
 
     public bool ParseHeaders(SequenceReader<byte> reader, NatsHeaders headers)
     {

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -17,7 +17,7 @@ public readonly record struct NatsMsg(
         in ReadOnlySequence<byte>? headersBuffer,
         in ReadOnlySequence<byte> payloadBuffer,
         INatsConnection? connection,
-        HeaderParser headerParser)
+        NatsHeaderParser headerParser)
     {
         NatsHeaders? headers = null;
 
@@ -81,7 +81,7 @@ public readonly record struct NatsMsg<T>(
         in ReadOnlySequence<byte>? headersBuffer,
         in ReadOnlySequence<byte> payloadBuffer,
         INatsConnection? connection,
-        HeaderParser headerParser,
+        NatsHeaderParser headerParser,
         INatsSerializer serializer)
     {
         // Consider an empty payload as null or default value for value types. This way we are able to

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -71,7 +71,7 @@ public sealed record NatsOpts
         Headers: true,
         AuthOpts: NatsAuthOpts.Default,
         TlsOpts: NatsTlsOpts.Default,
-        Serializer: JsonNatsSerializer.Default,
+        Serializer: NatsJsonSerializer.Default,
         LoggerFactory: NullLoggerFactory.Instance,
         WriterBufferSize: 65534, // 32767
         ReaderBufferSize: 1048576,

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -225,7 +225,7 @@ public abstract class NatsSubBase
     /// </summary>
     /// <param name="subject">Subject received for this subscription. This might not be the subject you subscribed to especially when using wildcards. For example, if you subscribed to events.* you may receive events.open.</param>
     /// <param name="replyTo">Subject the sender wants you to send messages back to it.</param>
-    /// <param name="headersBuffer">Raw headers bytes. You can use <see cref="NatsConnection"/> <see cref="HeaderParser"/> to decode them.</param>
+    /// <param name="headersBuffer">Raw headers bytes. You can use <see cref="NatsConnection"/> <see cref="NatsHeaderParser"/> to decode them.</param>
     /// <param name="payloadBuffer">Raw payload bytes.</param>
     /// <returns></returns>
     protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);

--- a/src/NATS.Client.JetStream/NatsJSSubConsume.cs
+++ b/src/NATS.Client.JetStream/NatsJSSubConsume.cs
@@ -111,7 +111,7 @@ public class NatsJSSubConsume<TMsg> : NatsSubBase, INatsJSSubConsume<TMsg>
         Connection.PubModelAsync(
             subject: $"{_context.Opts.ApiPrefix}.CONSUMER.MSG.NEXT.{_stream}.{_consumer}",
             data: request,
-            serializer: JsonNatsSerializer.Default,
+            serializer: NatsJsonSerializer.Default,
             replyTo: Subject,
             headers: default,
             cancellationToken);
@@ -153,7 +153,7 @@ public class NatsJSSubConsume<TMsg> : NatsSubBase, INatsJSSubConsume<TMsg>
             replyTo: Subject,
             headers: default,
             value: request,
-            serializer: JsonNatsSerializer.Default,
+            serializer: NatsJsonSerializer.Default,
             cancellationToken: default);
     }
 

--- a/src/NATS.Client.JetStream/NatsJSSubFetch.cs
+++ b/src/NATS.Client.JetStream/NatsJSSubFetch.cs
@@ -93,7 +93,7 @@ public class NatsJSSubFetch<TMsg> : NatsSubBase, INatsJSSubFetch<TMsg>
         Connection.PubModelAsync(
             subject: $"{_context.Opts.ApiPrefix}.CONSUMER.MSG.NEXT.{_stream}.{_consumer}",
             data: request,
-            serializer: JsonNatsSerializer.Default,
+            serializer: NatsJsonSerializer.Default,
             replyTo: Subject,
             headers: default,
             cancellationToken);
@@ -126,7 +126,7 @@ public class NatsJSSubFetch<TMsg> : NatsSubBase, INatsJSSubFetch<TMsg>
             replyTo: Subject,
             headers: default,
             value: request,
-            serializer: JsonNatsSerializer.Default,
+            serializer: NatsJsonSerializer.Default,
             cancellationToken: default);
     }
 

--- a/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
+++ b/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
@@ -28,7 +28,7 @@ public class LowLevelApiTest
         for (var i = 0; i < 10; i++)
         {
             var headers = new NatsHeaders { { "X-Test", $"value-{i}" } };
-            await nats.PubModelAsync<int>($"foo.data{i}", i, JsonNatsSerializer.Default, "bar", headers);
+            await nats.PubModelAsync<int>($"foo.data{i}", i, NatsJsonSerializer.Default, "bar", headers);
         }
 
         await nats.PubAsync("foo.done");

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.Auth.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.Auth.cs
@@ -32,7 +32,7 @@ public abstract partial class NatsConnectionTest
                 {
                     AuthOpts = NatsAuthOpts.Default with
                     {
-                        Nkey = "UALQSMXRSAA7ZXIGDDJBJ2JOYJVQIWM3LQVDM5KYIPG4EP3FAGJ47BOJ",
+                        NKey = "UALQSMXRSAA7ZXIGDDJBJ2JOYJVQIWM3LQVDM5KYIPG4EP3FAGJ47BOJ",
                         Seed = "SUAAVWRZG6M5FA5VRRGWSCIHKTOJC7EWNIT4JV3FTOIPO4OBFR5WA7X5TE",
                     },
                 }),

--- a/tests/NATS.Client.Core.Tests/NatsHeaderTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsHeaderTest.cs
@@ -34,7 +34,7 @@ public class NatsHeaderTest
     [Fact]
     public void ParserTests()
     {
-        var parser = new HeaderParser(Encoding.UTF8);
+        var parser = new NatsHeaderParser(Encoding.UTF8);
         var text = "NATS/1.0 123 Test Message\r\nk1: v1\r\nk2: v2-0\r\nk2: v2-1\r\na-long-header-key: value\r\nkey: a-long-header-value\r\n\r\n";
         var input = new SequenceReader<byte>(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text)));
         var headers = new NatsHeaders();
@@ -77,7 +77,7 @@ public class NatsHeaderTest
     [InlineData("test message", NatsHeaders.Messages.Text)]
     public void ParserMessageEnumTests(string message, NatsHeaders.Messages result)
     {
-        var parser = new HeaderParser(Encoding.UTF8);
+        var parser = new NatsHeaderParser(Encoding.UTF8);
         var text = $"NATS/1.0 100 {message}\r\n\r\n";
         var input = new SequenceReader<byte>(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text)));
         var headers = new NatsHeaders();
@@ -91,7 +91,7 @@ public class NatsHeaderTest
     {
         var exception = Assert.Throws<NatsException>(() =>
         {
-            var parser = new HeaderParser(Encoding.UTF8);
+            var parser = new NatsHeaderParser(Encoding.UTF8);
             var text = "NATS/2.0\r\n\r\n";
             var input = new SequenceReader<byte>(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text)));
             var headers = new NatsHeaders();
@@ -105,7 +105,7 @@ public class NatsHeaderTest
     {
         var exception = Assert.Throws<NatsException>(() =>
         {
-            var parser = new HeaderParser(Encoding.UTF8);
+            var parser = new NatsHeaderParser(Encoding.UTF8);
             var text = "NATS/1.0 x\r\n\r\n";
             var input = new SequenceReader<byte>(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text)));
             var headers = new NatsHeaders();
@@ -126,7 +126,7 @@ public class NatsHeaderTest
     [InlineData("NATS/1.0 123456 test test 3\r\nk:v\r\n\r\n", 123456, "test test 3", 1)]
     public void ParserHeaderVersionOnlyTests(string text, int code, string message, int headerCount)
     {
-        var parser = new HeaderParser(Encoding.UTF8);
+        var parser = new NatsHeaderParser(Encoding.UTF8);
         var input = new SequenceReader<byte>(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text)));
         var headers = new NatsHeaders();
         parser.ParseHeaders(input, headers);
@@ -143,7 +143,7 @@ public class NatsHeaderTest
         const string text1 = "NATS/1.0 123 Test ";
         const string text2 = "Message\r\n\r\n";
 
-        var parser = new HeaderParser(Encoding.UTF8);
+        var parser = new NatsHeaderParser(Encoding.UTF8);
         var builder = new SeqeunceBuilder();
         builder.Append(Encoding.UTF8.GetBytes(text1));
         builder.Append(Encoding.UTF8.GetBytes(text2));


### PR DESCRIPTION
- Consistently use `Nats` prefix on public classes
- Change `Nkey` -> `NKey`