### PR TITLE
Add connection state to nats connection interface

### DIFF
--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -6,6 +6,11 @@ namespace NATS.Client.Core;
 public interface INatsConnection
 {
     /// <summary>
+    /// Gets the current state of the NATS connection.
+    /// </summary>
+    NatsConnectionState ConnectionState { get; }
+
+    /// <summary>
     /// Send PING command and await PONG. Return value is similar as Round Trip Time (RTT).
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the command.</param>


### PR DESCRIPTION
**Summary**
This Pull Request aims to extend the `INatsConnection` interface by adding a new property `NatsConnectionState ConnectionState { get; }`. This new property will provide real-time information about the state of the NATS connection.

**Rationale**
1. Increased Transparency
Knowing the state of the NATS connection at any point in time is crucial for efficiently managing resources and ensuring that messages are successfully published or consumed. By exposing this state through `INatsConnection`, we allow all client code to make informed decisions based on the state.

2. Enhanced Control Flow
In multi-threaded and distributed applications like ours, it's vital to have more control over asynchronous operations. The ConnectionState property can serve as a gatekeeper before performing certain actions, like sending messages, thus minimizing failed attempts and errors.

For example, in the given Producer class:

```csharp
while (!cancellationToken.IsCancellationRequested)
{
    if (_nats.ConnectionState != NatsConnectionState.Open)
    {
        await Task.Delay(1000, cancellationToken);
        continue;
    }
    // ... (publish message)
}
```
Here, we can efficiently pause and resume the message-publishing loop based on the NATS connection state.

3. Simplified Debugging and Monitoring
By exposing the NATS connection state, we make it easier to debug issues related to connectivity. It becomes straightforward to write monitoring tools that can alert developers or take corrective action when the NATS connection transitions to an undesirable state.

**Conclusion**
Adding a `NatsConnectionState ConnectionState { get; }` property to the `INatsConnection` interface is a minimal yet powerful extension that can benefit virtually every NATS client application. It simplifies control flow, makes debugging easier, and increases transparency in system operations.