### PR TITLE
Fixing test flappers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,8 @@ jobs:
         run: dotnet test -c Debug --no-build tests/NATS.Client.Core.Tests/NATS.Client.Core.Tests.csproj
 
       - name: Test JetStream
-        run: dotnet test -c Debug --no-build tests/NATS.Client.JetStream.Tests/NATS.Client.JetStream.Tests.csproj
+        # This test is hanging sometimes. Find out where!
+        run: dotnet test -c Debug --no-build --logger:"console;verbosity=normal" tests/NATS.Client.JetStream.Tests/NATS.Client.JetStream.Tests.csproj
 
   memory_test:
     name: memory test

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -309,7 +309,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase, INatsJSConsume<TMsg>
             Pull(_maxMsgs, _maxBytes - _pendingBytes);
             ResetPending();
         }
-        else if (_maxBytes == 0 && _pendingMsgs <= _thresholdMsgs)
+        else if (_maxBytes == 0 && _pendingMsgs <= _thresholdMsgs && _pendingMsgs < _maxMsgs)
         {
             if (_debug)
                 _logger.LogDebug(NatsJSLogEvents.PendingCount, "Check pending messages {Pending}", _pendingMsgs);

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -276,7 +276,8 @@ internal class NatsJSConsume<TMsg> : NatsSubBase, INatsJSConsume<TMsg>
                     _serializer),
                 _context);
 
-            _pendingMsgs--;
+            if (_pendingMsgs > 0)
+                _pendingMsgs--;
 
             if (_maxBytes > 0)
             {

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -118,6 +118,7 @@ public class NatsJSConsumer
             cancellationToken);
 
         await sub.CallMsgNextAsync(
+            "init",
             new ConsumerGetnextRequest
             {
                 Batch = max.MaxMsgs,

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -119,6 +119,7 @@ public class NatsJSConsumer
             sub: sub,
             cancellationToken);
 
+        // Start consuming with the first Pull Request
         await sub.CallMsgNextAsync(
             "init",
             new ConsumerGetnextRequest
@@ -130,7 +131,6 @@ public class NatsJSConsumer
             },
             cancellationToken);
 
-        sub.ResetPending();
         sub.ResetHeartbeatTimer();
 
         return sub;

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -78,6 +78,8 @@ public class NatsJSConsumer
     {
         ThrowIfDeleted();
 
+        opts ??= new NatsJSConsumeOpts();
+
         var inbox = _context.NewInbox();
 
         var max = NatsJSOptsDefaults.SetMax(opts.MaxMsgs, opts.MaxBytes, opts.ThresholdMsgs, opts.ThresholdBytes);

--- a/src/NATS.Client.JetStream/NatsJSMsg.cs
+++ b/src/NATS.Client.JetStream/NatsJSMsg.cs
@@ -109,7 +109,7 @@ public readonly struct NatsJSMsg<T>
 
         return _msg.ReplyAsync(
             payload: payload,
-            opts: new NatsPubOpts {WaitUntilSent = opts.WaitUntilSent ?? _context.Opts.AckOpts.WaitUntilSent,},
+            opts: new NatsPubOpts { WaitUntilSent = opts.WaitUntilSent ?? _context.Opts.AckOpts.WaitUntilSent },
             cancellationToken: cancellationToken);
     }
 }

--- a/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
@@ -29,14 +29,9 @@ public class RequestReplyTest
 
         for (var i = 0; i < 10; i++)
         {
-            var rep = await nats.RequestAsync<int, int>(subject, i, replyOpts: natsSubOpts, cancellationToken: cancellationToken);
+            var rep = await nats.RequestAsync<int, int>(subject, i, replyOpts: natsSubOpts, cancellationToken: cancellationToken) ?? throw new TimeoutException("Request timeout");
 
-            if (rep == null)
-            {
-                throw new TimeoutException("Request timeout");
-            }
-
-            Assert.Equal(i * 2, rep?.Data);
+            Assert.Equal(i * 2, rep.Data);
         }
 
         await sub.DisposeAsync();


### PR DESCRIPTION
Mainly additional debugging and synchronization around pending numbers in consume.
* Added locking around pending
* More debugging info for pull requests
* Timeouts for potentially hanging tests