### PR TITLE
Implement NUID

### DIFF
--- a/sandbox/MicroBenchmark/MicroBenchmark.csproj
+++ b/sandbox/MicroBenchmark/MicroBenchmark.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/sandbox/MicroBenchmark/MicroBenchmark.csproj
+++ b/sandbox/MicroBenchmark/MicroBenchmark.csproj
@@ -3,9 +3,11 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
+++ b/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -20,16 +20,16 @@ namespace MicroBenchmark;
 [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
 public class NewInboxBenchmarks
 {
-    private char[] buf = new char[32];
+    private char[] _buf = new char[32];
 
-    private static readonly NatsOpts s_longPrefixOpt = NatsOpts.Default
+    private static readonly NatsOpts LongPrefixOpt = NatsOpts.Default
         with
-        {
-            InboxPrefix = "this-is-a-rather-long-prefix-that-we-use-here"
-        };
+    {
+        InboxPrefix = "this-is-a-rather-long-prefix-that-we-use-here",
+    };
 
     private static readonly NatsConnection _connectionDefaultPrefix = new();
-    private static readonly NatsConnection _connectionLongPrefix = new(s_longPrefixOpt);
+    private static readonly NatsConnection _connectionLongPrefix = new(LongPrefixOpt);
 
     [GlobalSetup]
     public void Setup()
@@ -41,7 +41,7 @@ public class NewInboxBenchmarks
     [SkipLocalsInit]
     public bool TryWriteNuid()
     {
-        return NuidWriter.TryWriteNuid(buf);
+        return NuidWriter.TryWriteNuid(_buf);
     }
 
     [Benchmark]

--- a/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
+++ b/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
@@ -1,11 +1,5 @@
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
-using System.Security.Cryptography;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using NATS.Client.Core;
 using NATS.Client.Core.Internal;
@@ -13,23 +7,22 @@ using NATS.Client.Core.Internal;
 namespace MicroBenchmark;
 
 [MemoryDiagnoser]
-
-[SimpleJob(RuntimeMoniker.Net80)]
-[SimpleJob(RuntimeMoniker.NativeAot80)]
 [SimpleJob(RuntimeMoniker.Net60)]
 [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.NativeAot80)]
 public class NewInboxBenchmarks
 {
-    private char[] _buf = new char[32];
-
     private static readonly NatsOpts LongPrefixOpt = NatsOpts.Default
         with
-    {
-        InboxPrefix = "this-is-a-rather-long-prefix-that-we-use-here",
-    };
+        {
+            InboxPrefix = "this-is-a-rather-long-prefix-that-we-use-here",
+        };
 
-    private static readonly NatsConnection _connectionDefaultPrefix = new();
-    private static readonly NatsConnection _connectionLongPrefix = new(LongPrefixOpt);
+    private static readonly NatsConnection ConnectionDefaultPrefix = new();
+    private static readonly NatsConnection ConnectionLongPrefix = new(LongPrefixOpt);
+
+    private char[] _buf = new char[32];
 
     [GlobalSetup]
     public void Setup()
@@ -47,12 +40,12 @@ public class NewInboxBenchmarks
     [Benchmark]
     public string NewInbox_ShortPrefix()
     {
-        return _connectionDefaultPrefix.NewInbox();
+        return ConnectionDefaultPrefix.NewInbox();
     }
 
     [Benchmark]
     public string NewInbox_LongPrefix()
     {
-        return _connectionLongPrefix.NewInbox();
+        return ConnectionLongPrefix.NewInbox();
     }
 }

--- a/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
+++ b/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
@@ -1,0 +1,58 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using NATS.Client.Core;
+using NATS.Client.Core.Internal;
+
+namespace MicroBenchmark;
+
+[MemoryDiagnoser]
+
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.NativeAot80)]
+[SimpleJob(RuntimeMoniker.Net60)]
+[SimpleJob(RuntimeMoniker.Net70, baseline: true)]
+public class NewInboxBenchmarks
+{
+    private char[] buf = new char[32];
+
+    private static readonly NatsOpts s_longPrefixOpt = NatsOpts.Default
+        with
+        {
+            InboxPrefix = "this-is-a-rather-long-prefix-that-we-use-here"
+        };
+
+    private static readonly NatsConnection _connectionDefaultPrefix = new();
+    private static readonly NatsConnection _connectionLongPrefix = new(s_longPrefixOpt);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        NuidWriter.TryWriteNuid(new char[100]);
+    }
+
+    [Benchmark(Baseline = true)]
+    [SkipLocalsInit]
+    public bool TryWriteNuid()
+    {
+        return NuidWriter.TryWriteNuid(buf);
+    }
+
+    [Benchmark]
+    public string NewInbox_ShortPrefix()
+    {
+        return _connectionDefaultPrefix.NewInbox();
+    }
+
+    [Benchmark]
+    public string NewInbox_LongPrefix()
+    {
+        return _connectionLongPrefix.NewInbox();
+    }
+}

--- a/sandbox/MicroBenchmark/Program.cs
+++ b/sandbox/MicroBenchmark/Program.cs
@@ -1,7 +1,3 @@
 using BenchmarkDotNet.Running;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-
-
-
-

--- a/sandbox/MicroBenchmark/Program.cs
+++ b/sandbox/MicroBenchmark/Program.cs
@@ -1,3 +1,7 @@
 using BenchmarkDotNet.Running;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+
+
+

--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -1,0 +1,140 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Security.Cryptography;
+
+namespace NATS.Client.Core.Internal;
+
+[SkipLocalsInit]
+internal sealed class NuidWriter
+{
+    private const nuint BASE = 62;
+    private const ulong MAX_SEQUENTIAL = 839299365868340224; // 62^10   // 0x1000_0000_0000_0000; // 64 ^10
+    private const uint PREFIX_LENGTH = 12;
+    private const nuint SEQUENTIAL_LENGTH = 10;
+    private const int MIN_INCREMENT = 33;
+    private const int MAX_INCREMENT = 333;
+    internal const nuint NUID_LENGTH = PREFIX_LENGTH + SEQUENTIAL_LENGTH;
+
+    [ThreadStatic]
+    private static NuidWriter? t_writer;
+
+    // TODO: Use UTF8 string literal when upgrading to .NET 7+
+    private static ReadOnlySpan<char> Digits => "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    private char[] _prefix;
+    private ulong _increment;
+    private ulong _sequential;
+
+    internal static int PrefixLength => (int)PREFIX_LENGTH;
+
+    private NuidWriter()
+    {
+        Refresh(out _);
+    }
+
+    public static bool TryWriteNuid(Span<char> nuidBuffer)
+    {
+        if(t_writer is not null)
+        {
+            return t_writer.TryWriteNuidCore(nuidBuffer);
+        }
+
+        return InitAndWrite(nuidBuffer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool InitAndWrite(Span<char> span)
+    {
+        t_writer = new NuidWriter();
+        return t_writer.TryWriteNuidCore(span);
+    }
+
+    private bool TryWriteNuidCore(Span<char> nuidBuffer)
+    {
+        ulong sequential = _sequential += _increment;
+
+        if(sequential < MAX_SEQUENTIAL)
+        {
+            return TryWriteNuidCore(nuidBuffer, _prefix, sequential);
+        }
+
+        return RefreshAndWrite(nuidBuffer);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        bool RefreshAndWrite(Span<char> buffer)
+        {
+            char[] prefix = Refresh(out sequential);
+            return TryWriteNuidCore(buffer, prefix, sequential);
+        }
+    }
+
+    private static bool TryWriteNuidCore(Span<char> buffer, Span<char> prefix, ulong sequential)
+    {
+        if ((uint)buffer.Length < NUID_LENGTH || prefix.Length != PREFIX_LENGTH || (uint)prefix.Length > (uint)buffer.Length)
+        {
+            return false;
+        }
+
+        Unsafe.CopyBlockUnaligned(ref Unsafe.As<char, byte>(ref buffer[0]), ref Unsafe.As<char, byte>(ref prefix[0]), PREFIX_LENGTH * sizeof(char));
+
+        // NOTE: We must never write to digitsPtr!
+        ref char digitsPtr = ref MemoryMarshal.GetReference(Digits);
+
+        for(nuint i = PREFIX_LENGTH; i < NUID_LENGTH; i++)
+        {
+            nuint digitIndex = (nuint)(sequential % BASE);
+            Unsafe.Add(ref buffer[0], i) = Unsafe.Add(ref digitsPtr, digitIndex);
+            sequential /= BASE;
+        }
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [MemberNotNull(nameof(_prefix))]
+    private char[] Refresh(out ulong sequential)
+    {
+        char[] prefix = _prefix = GetPrefix();
+        _increment = GetIncrement();
+        sequential = _sequential = GetSequential();
+        return prefix;
+    }
+
+    private static uint GetIncrement()
+    {
+        return (uint)Random.Shared.Next(MIN_INCREMENT, MAX_INCREMENT + 1);
+    }
+
+    private static ulong GetSequential()
+    {
+        return (ulong)Random.Shared.NextInt64(0, (long)MAX_SEQUENTIAL + 1);
+    }
+
+    private static char[] GetPrefix(RandomNumberGenerator? rng = null)
+    {
+        Span<byte> randomBytes = stackalloc byte[(int)PREFIX_LENGTH];
+
+        // TODO: For .NET 8+, use GetItems for better distribution
+        if(rng == null)
+        {
+            RandomNumberGenerator.Fill(randomBytes);
+        }
+        else
+        {
+            rng.GetBytes(randomBytes);
+        }
+
+        char[] newPrefix = new char[PREFIX_LENGTH];
+
+        for(int i = 0; i < randomBytes.Length; i++)
+        {
+            int digitIndex = (int)(randomBytes[i] % BASE);
+            newPrefix[i] = Digits[digitIndex];
+        }
+
+        return newPrefix;
+    }
+}
+

--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -42,7 +42,7 @@ internal sealed class NuidWriter
 
     private static bool TryWriteNuidCore(Span<char> buffer, Span<char> prefix, ulong sequential)
     {
-        if ((uint)buffer.Length < NuidLength || prefix.Length != PrefixLength || (uint)prefix.Length > (uint)buffer.Length)
+        if ((uint)buffer.Length < NuidLength || prefix.Length != PrefixLength)
         {
             return false;
         }

--- a/src/NATS.Client.Core/Internal/SubscriptionManager.cs
+++ b/src/NATS.Client.Core/Internal/SubscriptionManager.cs
@@ -180,7 +180,7 @@ internal sealed class SubscriptionManager : ISubscriptionManager, IAsyncDisposab
             {
                 if (Interlocked.CompareExchange(ref _inboxSub, _inboxSubSentinel, _inboxSubSentinel) == _inboxSubSentinel)
                 {
-                    var inboxSubject = $"{_inboxPrefix}*";
+                    var inboxSubject = $"{_inboxPrefix}.*";
                     _inboxSub = InboxSubBuilder.Build(subject, opts, _connection, manager: this);
                     await SubscribeInternalAsync(
                         inboxSubject,

--- a/src/NATS.Client.Core/NATS.Client.Core.csproj
+++ b/src/NATS.Client.Core/NATS.Client.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/NATS.Client.Core/NATS.Client.Core.csproj
+++ b/src/NATS.Client.Core/NATS.Client.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -20,6 +20,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.IO.Hashing" Version="6.0.1" />
+
+        <InternalsVisibleTo  Include="MicroBenchmark, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd" />
         <InternalsVisibleTo Include="$(AssemblyName).Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd" />
         <InternalsVisibleTo Include="$(AssemblyName).MemoryTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd" />
         <InternalsVisibleTo Include="NatsBenchmark, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd" />

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -17,24 +17,24 @@ public partial class NatsConnection
     private static string NewInbox(ReadOnlySpan<char> prefix)
     {
         Span<char> buffer = stackalloc char[64];
-        uint separatorLength = prefix.Length > 0 ? 1u : 0u;
-        uint totalLength = (uint)prefix.Length + (uint)NuidWriter.NUID_LENGTH + separatorLength;
+        var separatorLength = prefix.Length > 0 ? 1u : 0u;
+        var totalLength = (uint)prefix.Length + (uint)NuidWriter.NUIDLENGTH + separatorLength;
         if (totalLength <= buffer.Length)
         {
-             buffer = buffer.Slice(0, (int)totalLength);
+            buffer = buffer.Slice(0, (int)totalLength);
         }
         else
         {
             buffer = new char[totalLength];
         }
 
-        uint totalPrefixLength = (uint)prefix.Length + separatorLength;
+        var totalPrefixLength = (uint)prefix.Length + separatorLength;
         if ((uint)buffer.Length > totalPrefixLength && (uint)buffer.Length > (uint)prefix.Length)
         {
             prefix.CopyTo(buffer);
             buffer[prefix.Length] = '.';
-            Span<char> remaining = buffer.Slice((int)totalPrefixLength);
-            bool didWrite = NuidWriter.TryWriteNuid(remaining);
+            var remaining = buffer.Slice((int)totalPrefixLength);
+            var didWrite = NuidWriter.TryWriteNuid(remaining);
             Debug.Assert(didWrite, "didWrite");
             return new string(buffer);
         }

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -12,42 +11,6 @@ public partial class NatsConnection
 
     /// <inheritdoc />
     public string NewInbox() => NewInbox(InboxPrefix);
-
-    [SkipLocalsInit]
-    private static string NewInbox(ReadOnlySpan<char> prefix)
-    {
-        Span<char> buffer = stackalloc char[64];
-        var separatorLength = prefix.Length > 0 ? 1u : 0u;
-        var totalLength = (uint)prefix.Length + (uint)NuidWriter.NUIDLENGTH + separatorLength;
-        if (totalLength <= buffer.Length)
-        {
-            buffer = buffer.Slice(0, (int)totalLength);
-        }
-        else
-        {
-            buffer = new char[totalLength];
-        }
-
-        var totalPrefixLength = (uint)prefix.Length + separatorLength;
-        if ((uint)buffer.Length > totalPrefixLength && (uint)buffer.Length > (uint)prefix.Length)
-        {
-            prefix.CopyTo(buffer);
-            buffer[prefix.Length] = '.';
-            var remaining = buffer.Slice((int)totalPrefixLength);
-            var didWrite = NuidWriter.TryWriteNuid(remaining);
-            Debug.Assert(didWrite, "didWrite");
-            return new string(buffer);
-        }
-
-        return Throw();
-
-        [DoesNotReturn]
-        string Throw()
-        {
-            Debug.Fail("Must not happen");
-            throw new InvalidOperationException("This should never be raised!");
-        }
-    }
 
     /// <inheritdoc />
     public async ValueTask<NatsMsg<TReply?>?> RequestAsync<TRequest, TReply>(
@@ -98,6 +61,42 @@ public partial class NatsConnection
 
                 yield return msg;
             }
+        }
+    }
+
+    [SkipLocalsInit]
+    private static string NewInbox(ReadOnlySpan<char> prefix)
+    {
+        Span<char> buffer = stackalloc char[64];
+        var separatorLength = prefix.Length > 0 ? 1u : 0u;
+        var totalLength = (uint)prefix.Length + (uint)NuidWriter.NuidLength + separatorLength;
+        if (totalLength <= buffer.Length)
+        {
+            buffer = buffer.Slice(0, (int)totalLength);
+        }
+        else
+        {
+            buffer = new char[totalLength];
+        }
+
+        var totalPrefixLength = (uint)prefix.Length + separatorLength;
+        if ((uint)buffer.Length > totalPrefixLength && (uint)buffer.Length > (uint)prefix.Length)
+        {
+            prefix.CopyTo(buffer);
+            buffer[prefix.Length] = '.';
+            var remaining = buffer.Slice((int)totalPrefixLength);
+            var didWrite = NuidWriter.TryWriteNuid(remaining);
+            Debug.Assert(didWrite, "didWrite");
+            return new string(buffer);
+        }
+
+        return Throw();
+
+        [DoesNotReturn]
+        string Throw()
+        {
+            Debug.Fail("Must not happen");
+            throw new InvalidOperationException("This should never be raised!");
         }
     }
 

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -1,4 +1,8 @@
+using System.Buffers;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using NATS.Client.Core.Internal;
 
 namespace NATS.Client.Core;
 
@@ -7,7 +11,43 @@ public partial class NatsConnection
     private static readonly NatsSubOpts DefaultReplyOpts = new() { MaxMsgs = 1 };
 
     /// <inheritdoc />
-    public string NewInbox() => $"{InboxPrefix}{Guid.NewGuid():n}";
+    public string NewInbox() => NewInbox(InboxPrefix);
+
+    [SkipLocalsInit]
+    private static string NewInbox(ReadOnlySpan<char> prefix)
+    {
+        Span<char> buffer = stackalloc char[64];
+        uint separatorLength = prefix.Length > 0 ? 1u : 0u;
+        uint totalLength = (uint)prefix.Length + (uint)NuidWriter.NUID_LENGTH + separatorLength;
+        if (totalLength <= buffer.Length)
+        {
+             buffer = buffer.Slice(0, (int)totalLength);
+        }
+        else
+        {
+            buffer = new char[totalLength];
+        }
+
+        uint totalPrefixLength = (uint)prefix.Length + separatorLength;
+        if ((uint)buffer.Length > totalPrefixLength && (uint)buffer.Length > (uint)prefix.Length)
+        {
+            prefix.CopyTo(buffer);
+            buffer[prefix.Length] = '.';
+            Span<char> remaining = buffer.Slice((int)totalPrefixLength);
+            bool didWrite = NuidWriter.TryWriteNuid(remaining);
+            Debug.Assert(didWrite, "didWrite");
+            return new string(buffer);
+        }
+
+        return Throw();
+
+        [DoesNotReturn]
+        string Throw()
+        {
+            Debug.Fail("Must not happen");
+            throw new InvalidOperationException("This should never be raised!");
+        }
+    }
 
     /// <inheritdoc />
     public async ValueTask<NatsMsg<TReply?>?> RequestAsync<TRequest, TReply>(

--- a/src/NATS.Client.Core/NatsConnection.RequestSub.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestSub.cs
@@ -10,7 +10,7 @@ public partial class NatsConnection
         NatsSubOpts? replyOpts = default,
         CancellationToken cancellationToken = default)
     {
-        var replyTo = $"{InboxPrefix}{Guid.NewGuid():n}";
+        var replyTo = NewInbox();
 
         var replySerializer = replyOpts?.Serializer ?? Opts.Serializer;
         var sub = new NatsSub<TReply>(this, SubscriptionManager.InboxSubBuilder, replyTo, queueGroup: default, replyOpts, replySerializer);

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -68,7 +68,7 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
         Counter = new ConnectionStatsCounter();
         _writerState = new WriterState(opts);
         _commandWriter = _writerState.CommandBuffer.Writer;
-        InboxPrefix = $"{opts.InboxPrefix}.{Guid.NewGuid():n}.";
+        InboxPrefix = NewInbox(opts.InboxPrefix);
         SubscriptionManager = new SubscriptionManager(this, InboxPrefix);
         _logger = opts.LoggerFactory.CreateLogger<NatsConnection>();
         _clientOpts = ClientOpts.Create(Opts);

--- a/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
+++ b/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
@@ -213,8 +213,7 @@ public class NuidWriterTests
         Assert.Equal(10, uniqueThreadIds.Count);
     }
 
-    [Fact]
-    [Trait("Category", "long-running")]
+    [Fact(Skip = "long running")]
     public void AllNuidsAreUnique()
     {
         const int count = 1_000 * 1_000 * 10;
@@ -240,8 +239,7 @@ public class NuidWriterTests
         }
     }
 
-    [Fact]
-    [Trait("Category", "long-running")]
+    [Fact(Skip = "long running")]
     public void AllNuidsAreUnique_SmallSequentials()
     {
         var writeFailed = false;
@@ -284,8 +282,7 @@ public class NuidWriterTests
         Assert.Equal(string.Empty, duplicateFailure);
     }
 
-    [Fact]
-    [Trait("Category", "long-running")]
+    [Fact(Skip = "long running")]
     public void AllNuidsAreUnique_ZeroSequential()
     {
         var writeFailed = false;

--- a/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
+++ b/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
@@ -1,0 +1,373 @@
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace NATS.Client.Core.Tests;
+
+public class NuidWriterTests
+{
+    private static readonly Regex _nuidRegex = new Regex("[A-z0-9]{22}");
+
+    private readonly ITestOutputHelper _outputHelper;
+
+    public NuidWriterTests(ITestOutputHelper outputHelper)
+    {
+        _outputHelper = outputHelper;
+    }
+
+    [Theory]
+    [InlineData(default(string))]
+    [InlineData("")]
+    [InlineData("__INBOX")]
+    [InlineData("long-inbox-prefix-above-stackalloc-limit-of-64")]
+    public void NewInbox_NuidAppended(string? prefix)
+    {
+        var natsOpts = NatsOpts.Default with { InboxPrefix = prefix };
+        var sut = new NatsConnection(natsOpts);
+
+        var inbox = sut.InboxPrefix;
+        var newInbox = sut.NewInbox();
+
+        Assert.Matches($"{prefix ?? ""}{(prefix?.Length > 0 ? "." : "")}[A-z0-9]{{22}}", inbox);
+        Assert.Matches($"{prefix ?? ""}{(prefix?.Length > 0 ? "." : "")}[A-z0-9]{{22}}.[A-z0-9]{{22}}", newInbox);
+        _outputHelper.WriteLine($"Prefix:   '{prefix}'");
+        _outputHelper.WriteLine($"Inbox:    '{inbox}'");
+        _outputHelper.WriteLine($"NewInbox: '{newInbox}'");
+    }
+
+    [Fact]
+    public void GetNextNuid_ReturnsNuidOfLength22_Char()
+    {
+        // Arrange
+        Span<char> buffer = stackalloc char[44];
+
+        // Act
+        bool result = NuidWriter.TryWriteNuid(buffer);
+
+        // Assert
+        ReadOnlySpan<char> lower = buffer.Slice(0, 22);
+        string resultAsString = new(lower);
+        ReadOnlySpan<char> upper = buffer.Slice(22);
+
+        Assert.True(result);
+
+        Assert.Matches("[A-z0-9]{22}", resultAsString);
+        Assert.All(upper.ToArray(), b => Assert.Equal(0, b));
+    }
+
+    [Fact]
+    public void GetNextNuid_BufferToShort_False_Char()
+    {
+        // Arrange
+        Span<char> nuid = stackalloc char[(int)NuidWriter.NUID_LENGTH - 1];
+
+        // Act
+        bool result = NuidWriter.TryWriteNuid(nuid);
+
+        // Assert
+        Assert.False(result);
+        Assert.All(nuid.ToArray(), b => Assert.Equal(0, b));
+    }
+
+    [Fact]
+    public void GetNextNuid_ReturnsDifferentNuidEachTime_Char()
+    {
+        // Arrange
+        Span<char> firstNuid = stackalloc char[22];
+        Span<char> secondNuid = stackalloc char[22];
+
+        // Act
+        bool result = NuidWriter.TryWriteNuid(firstNuid);
+        result &= NuidWriter.TryWriteNuid(secondNuid);
+
+        // Assert
+        Assert.False(firstNuid.SequenceEqual(secondNuid));
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void GetNextNuid_PrefixIsConstant_Char()
+    {
+        // Arrange
+        Span<char> firstNuid = stackalloc char[22];
+        Span<char> secondNuid = stackalloc char[22];
+
+        // Act
+        bool result = NuidWriter.TryWriteNuid(firstNuid);
+        result &= NuidWriter.TryWriteNuid(secondNuid);
+
+        // Assert
+        Assert.True(result);
+        Assert.True(firstNuid.Slice(0, 12).SequenceEqual(secondNuid.Slice(0, 12)));
+    }
+
+    [Fact]
+    public void GetNextNuid_ContainsOnlyValidCharacters_Char()
+    {
+        // Arrange
+        Span<char> nuid = stackalloc char[22];
+
+        // Act
+        bool result = NuidWriter.TryWriteNuid(nuid);
+
+        // Assert
+        Assert.True(result);
+        string resultAsString = new(nuid);
+        Assert.Matches("[A-z0-9]{22}", resultAsString);
+    }
+
+    [Fact]
+    public void GetNextNuid_PrefixRenewed_Char()
+    {
+        bool result = false;
+        char[] firstNuid = new char[22];
+        char[] secondNuid = new char[22];
+
+        Thread executionThread = new Thread(() =>
+        {
+            uint increment = 100U;
+            ulong maxSequential = 839299365868340224ul - increment - 1;
+            SetSequentialAndIncrement(maxSequential, increment);
+
+            result = NuidWriter.TryWriteNuid(firstNuid);
+            result &= NuidWriter.TryWriteNuid(secondNuid);
+        });
+
+        executionThread.Start();
+        executionThread.Join(1_000);
+
+
+        // Assert
+        Assert.True(result);
+        Assert.False(firstNuid.AsSpan(0, 12).SequenceEqual(secondNuid.AsSpan(0, 12)));
+    }
+
+    [Fact]
+    public void GetPrefix_PrefixAsExpected()
+    {
+        // Arrange
+        byte[] rngBytes = new byte[12] { 0, 1, 2, 3, 4, 5, 6, 7, 11, 253, 254, 255 };
+        DeterministicRng rng = new(new Queue<byte[]>(new[] { rngBytes, rngBytes }));
+
+        MethodInfo mi = typeof(NuidWriter).GetMethod("GetPrefix", BindingFlags.Static | BindingFlags.NonPublic);
+        Func<RandomNumberGenerator, char[]> mGetPrefix = mi!.CreateDelegate<Func<RandomNumberGenerator, char[]>>();
+
+        // Act
+        char[] prefix = mGetPrefix(rng);
+
+        // Assert
+        Assert.Equal(12, prefix.Length);
+        Assert.True("01234567B567".AsSpan().SequenceEqual(prefix));
+    }
+
+    [Fact]
+    public void InitAndWrite_Char()
+    {
+        bool completedSuccessfully = false;
+        Thread t = new(() =>
+        {
+            char[] buffer = new char[22];
+            bool didWrite = NuidWriter.TryWriteNuid(buffer);
+
+            bool isMatch = _nuidRegex.IsMatch(new string(buffer));
+            Volatile.Write(ref completedSuccessfully, didWrite && isMatch);
+        });
+        t.Start();
+        t.Join(1_000);
+
+        Assert.True(completedSuccessfully);
+    }
+
+    [Fact]
+    public void DifferentThreads_DifferentPrefixes()
+    {
+        // Arrange
+        ConcurrentQueue<(char[] nuid, int threadId)> nuids = new();
+
+        // Act
+        for (int i = 0; i < 10; i++)
+        {
+            Thread t = new(() =>
+            {
+                char[] buffer = new char[22];
+                NuidWriter.TryWriteNuid(buffer);
+                nuids.Enqueue((buffer, Environment.CurrentManagedThreadId));
+            });
+            t.Start();
+            t.Join(1_000);
+
+        }
+
+        // Assert
+        HashSet<string> uniquePrefixes = new HashSet<string>();
+        HashSet<int> uniqueThreadIds = new HashSet<int>();
+
+        foreach ((char[] nuid, int threadId) in nuids.ToList())
+        {
+            string prefix = new string(nuid.AsSpan(0, NuidWriter.PrefixLength));
+            Assert.True(uniquePrefixes.Add(prefix), $"Unique prefix {prefix}");
+            Assert.True(uniqueThreadIds.Add(threadId), $"Unique thread id {threadId}");
+        }
+
+        Assert.Equal(10, uniquePrefixes.Count);
+        Assert.Equal(10, uniqueThreadIds.Count);
+    }
+
+    [Fact]
+    [Trait("Category", "long-running")]
+    public void AllNuidsAreUnique()
+    {
+        const int count = 1_000 * 1_000 * 10;
+        HashSet<string> nuids = new HashSet<string>(count);
+
+        char[] buffer = new char[22];
+
+        for (int i = 0; i < count; i++)
+        {
+            bool didWrite = NuidWriter.TryWriteNuid(buffer);
+
+            if (!didWrite)
+            {
+                Assert.Fail($"Failed to write Nuid, i: {i}");
+            }
+
+            string nuid = new(buffer);
+
+            if (!nuids.Add(nuid))
+            {
+                Assert.Fail($"Duplicate Nuid: {nuid} i: {i}");
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "long-running")]
+    public void AllNuidsAreUnique_SmallSequentials()
+    {
+        bool writeFailed = false;
+        string duplicateFailure = "";
+        Thread executionThread = new Thread(() =>
+        {
+            Span<char> buffer = new char[22];
+            for (uint seq = 0; seq < 128; seq++)
+            {
+                for (uint incr = 33; incr <= 333; incr++)
+                {
+                    HashSet<string> nuids = new(2048);
+                    SetSequentialAndIncrement(seq, incr);
+
+                    for (int i = 0; i < 2048; i++)
+                    {
+                        if (!NuidWriter.TryWriteNuid(buffer))
+                        {
+                            writeFailed = true;
+                            return;
+                        }
+
+                        //_outputHelper.WriteLine(buffer.ToString());
+
+                        string nuid = new string(buffer);
+
+                        if (!nuids.Add(nuid))
+                        {
+                            duplicateFailure = $"Duplicate nuid: {nuid} seq: {seq} incr: {incr} i: {i}";
+                        }
+                    }
+                }
+            }
+        });
+
+        executionThread.Start();
+        executionThread.Join(60_000);
+
+        Interlocked.MemoryBarrier();
+
+        Assert.False(writeFailed);
+        Assert.Equal("", duplicateFailure);
+    }
+
+    [Fact]
+    [Trait("Category", "long-running")]
+    public void AllNuidsAreUnique_ZeroSequential()
+    {
+        bool writeFailed = false;
+        string duplicateFailure = "";
+        Thread executionThread = new Thread(() =>
+        {
+            uint seq = 0;
+            uint incr = 33;
+
+            HashSet<string> nuids = new(2048);
+            SetSequentialAndIncrement(seq, incr);
+
+            Span<char> buffer = new char[22];
+            for (int i = 0; i < 100_000_000; i++)
+            {
+                if (!NuidWriter.TryWriteNuid(buffer))
+                {
+                    writeFailed = true;
+                    return;
+                }
+
+                //_outputHelper.WriteLine(buffer.ToString());
+
+                string nuid = new string(buffer);
+
+                if (!nuids.Add(nuid))
+                {
+                    duplicateFailure = $"Duplicate nuid: {nuid} seq: {seq} incr: {incr} i: {i}";
+                }
+            }
+        });
+
+        executionThread.Start();
+        executionThread.Join(120_000);
+
+        Interlocked.MemoryBarrier();
+
+        Assert.False(writeFailed);
+        Assert.Equal("", duplicateFailure);
+    }
+
+    // This messes with NuidWriter's internal state and must be used
+    // on separate threads (distinct NuidWriter instances) only.
+    private static void SetSequentialAndIncrement(ulong sequential, ulong increment)
+    {
+        bool didWrite = NuidWriter.TryWriteNuid(new char[128]);
+
+        Assert.True(didWrite, "didWrite");
+
+        FieldInfo fInstance = typeof(NuidWriter).GetField("t_writer", BindingFlags.Static | BindingFlags.NonPublic);
+        object instance = fInstance.GetValue(null);
+
+        FieldInfo fSequential = typeof(NuidWriter).GetField("_sequential", BindingFlags.Instance | BindingFlags.NonPublic);
+        fSequential.SetValue(instance, sequential);
+
+        FieldInfo fIncrement = typeof(NuidWriter).GetField("_increment", BindingFlags.Instance | BindingFlags.NonPublic);
+        fIncrement.SetValue(instance, increment);
+    }
+
+    private sealed class DeterministicRng : RandomNumberGenerator
+    {
+        public int GetBytesInvocations;
+        private readonly Queue<byte[]> _bytes;
+
+        public DeterministicRng(Queue<byte[]> bytes)
+        {
+            _bytes = bytes;
+        }
+
+        public override void GetBytes(byte[] buffer)
+        {
+            byte[] nextBytes = _bytes.Dequeue();
+            if(nextBytes.Length < buffer.Length)
+                throw new InvalidOperationException($"Lenght of {nameof(buffer)} is {buffer.Length}, length of {nameof(nextBytes)} is {nextBytes.Length}");
+
+            Array.Copy(nextBytes, buffer, buffer.Length);
+            GetBytesInvocations++;
+        }
+    }
+}

--- a/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
+++ b/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
@@ -333,7 +333,7 @@ public class NuidWriterTests
 
         Assert.True(didWrite, "didWrite");
 
-        var fInstance = typeof(NuidWriter).GetField("t_writer", BindingFlags.Static | BindingFlags.NonPublic);
+        var fInstance = typeof(NuidWriter).GetField("_writer", BindingFlags.Static | BindingFlags.NonPublic);
         var instance = fInstance!.GetValue(null);
 
         var fSequential = typeof(NuidWriter).GetField("_sequential", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
+++ b/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
@@ -31,8 +31,8 @@ public class NuidWriterTests
         var inbox = sut.InboxPrefix;
         var newInbox = sut.NewInbox();
 
-        Assert.Matches($"{prefix ?? ""}{(prefix?.Length > 0 ? "." : "")}[A-z0-9]{{22}}", inbox);
-        Assert.Matches($"{prefix ?? ""}{(prefix?.Length > 0 ? "." : "")}[A-z0-9]{{22}}.[A-z0-9]{{22}}", newInbox);
+        Assert.Matches($"{prefix ?? string.Empty}{(prefix?.Length > 0 ? "." : string.Empty)}[A-z0-9]{{22}}", inbox);
+        Assert.Matches($"{prefix ?? string.Empty}{(prefix?.Length > 0 ? "." : string.Empty)}[A-z0-9]{{22}}.[A-z0-9]{{22}}", newInbox);
         _outputHelper.WriteLine($"Prefix:   '{prefix}'");
         _outputHelper.WriteLine($"Inbox:    '{inbox}'");
         _outputHelper.WriteLine($"NewInbox: '{newInbox}'");
@@ -45,7 +45,7 @@ public class NuidWriterTests
         Span<char> buffer = stackalloc char[44];
 
         // Act
-        bool result = NuidWriter.TryWriteNuid(buffer);
+        var result = NuidWriter.TryWriteNuid(buffer);
 
         // Assert
         ReadOnlySpan<char> lower = buffer.Slice(0, 22);
@@ -62,10 +62,10 @@ public class NuidWriterTests
     public void GetNextNuid_BufferToShort_False_Char()
     {
         // Arrange
-        Span<char> nuid = stackalloc char[(int)NuidWriter.NUID_LENGTH - 1];
+        Span<char> nuid = stackalloc char[(int)NuidWriter.NUIDLENGTH - 1];
 
         // Act
-        bool result = NuidWriter.TryWriteNuid(nuid);
+        var result = NuidWriter.TryWriteNuid(nuid);
 
         // Assert
         Assert.False(result);
@@ -80,7 +80,7 @@ public class NuidWriterTests
         Span<char> secondNuid = stackalloc char[22];
 
         // Act
-        bool result = NuidWriter.TryWriteNuid(firstNuid);
+        var result = NuidWriter.TryWriteNuid(firstNuid);
         result &= NuidWriter.TryWriteNuid(secondNuid);
 
         // Assert
@@ -96,7 +96,7 @@ public class NuidWriterTests
         Span<char> secondNuid = stackalloc char[22];
 
         // Act
-        bool result = NuidWriter.TryWriteNuid(firstNuid);
+        var result = NuidWriter.TryWriteNuid(firstNuid);
         result &= NuidWriter.TryWriteNuid(secondNuid);
 
         // Assert
@@ -111,7 +111,7 @@ public class NuidWriterTests
         Span<char> nuid = stackalloc char[22];
 
         // Act
-        bool result = NuidWriter.TryWriteNuid(nuid);
+        var result = NuidWriter.TryWriteNuid(nuid);
 
         // Assert
         Assert.True(result);
@@ -122,14 +122,14 @@ public class NuidWriterTests
     [Fact]
     public void GetNextNuid_PrefixRenewed_Char()
     {
-        bool result = false;
-        char[] firstNuid = new char[22];
-        char[] secondNuid = new char[22];
+        var result = false;
+        var firstNuid = new char[22];
+        var secondNuid = new char[22];
 
-        Thread executionThread = new Thread(() =>
+        var executionThread = new Thread(() =>
         {
-            uint increment = 100U;
-            ulong maxSequential = 839299365868340224ul - increment - 1;
+            var increment = 100U;
+            var maxSequential = 839299365868340224ul - increment - 1;
             SetSequentialAndIncrement(maxSequential, increment);
 
             result = NuidWriter.TryWriteNuid(firstNuid);
@@ -138,7 +138,6 @@ public class NuidWriterTests
 
         executionThread.Start();
         executionThread.Join(1_000);
-
 
         // Assert
         Assert.True(result);
@@ -149,14 +148,14 @@ public class NuidWriterTests
     public void GetPrefix_PrefixAsExpected()
     {
         // Arrange
-        byte[] rngBytes = new byte[12] { 0, 1, 2, 3, 4, 5, 6, 7, 11, 253, 254, 255 };
+        var rngBytes = new byte[12] { 0, 1, 2, 3, 4, 5, 6, 7, 11, 253, 254, 255 };
         DeterministicRng rng = new(new Queue<byte[]>(new[] { rngBytes, rngBytes }));
 
-        MethodInfo mi = typeof(NuidWriter).GetMethod("GetPrefix", BindingFlags.Static | BindingFlags.NonPublic);
-        Func<RandomNumberGenerator, char[]> mGetPrefix = mi!.CreateDelegate<Func<RandomNumberGenerator, char[]>>();
+        var mi = typeof(NuidWriter).GetMethod("GetPrefix", BindingFlags.Static | BindingFlags.NonPublic);
+        var mGetPrefix = mi!.CreateDelegate<Func<RandomNumberGenerator, char[]>>();
 
         // Act
-        char[] prefix = mGetPrefix(rng);
+        var prefix = mGetPrefix(rng);
 
         // Assert
         Assert.Equal(12, prefix.Length);
@@ -166,13 +165,13 @@ public class NuidWriterTests
     [Fact]
     public void InitAndWrite_Char()
     {
-        bool completedSuccessfully = false;
+        var completedSuccessfully = false;
         Thread t = new(() =>
         {
-            char[] buffer = new char[22];
-            bool didWrite = NuidWriter.TryWriteNuid(buffer);
+            var buffer = new char[22];
+            var didWrite = NuidWriter.TryWriteNuid(buffer);
 
-            bool isMatch = _nuidRegex.IsMatch(new string(buffer));
+            var isMatch = _nuidRegex.IsMatch(new string(buffer));
             Volatile.Write(ref completedSuccessfully, didWrite && isMatch);
         });
         t.Start();
@@ -188,26 +187,25 @@ public class NuidWriterTests
         ConcurrentQueue<(char[] nuid, int threadId)> nuids = new();
 
         // Act
-        for (int i = 0; i < 10; i++)
+        for (var i = 0; i < 10; i++)
         {
             Thread t = new(() =>
             {
-                char[] buffer = new char[22];
+                var buffer = new char[22];
                 NuidWriter.TryWriteNuid(buffer);
                 nuids.Enqueue((buffer, Environment.CurrentManagedThreadId));
             });
             t.Start();
             t.Join(1_000);
-
         }
 
         // Assert
-        HashSet<string> uniquePrefixes = new HashSet<string>();
-        HashSet<int> uniqueThreadIds = new HashSet<int>();
+        var uniquePrefixes = new HashSet<string>();
+        var uniqueThreadIds = new HashSet<int>();
 
-        foreach ((char[] nuid, int threadId) in nuids.ToList())
+        foreach ((var nuid, var threadId) in nuids.ToList())
         {
-            string prefix = new string(nuid.AsSpan(0, NuidWriter.PrefixLength));
+            var prefix = new string(nuid.AsSpan(0, NuidWriter.PrefixLength));
             Assert.True(uniquePrefixes.Add(prefix), $"Unique prefix {prefix}");
             Assert.True(uniqueThreadIds.Add(threadId), $"Unique thread id {threadId}");
         }
@@ -221,13 +219,13 @@ public class NuidWriterTests
     public void AllNuidsAreUnique()
     {
         const int count = 1_000 * 1_000 * 10;
-        HashSet<string> nuids = new HashSet<string>(count);
+        var nuids = new HashSet<string>(count);
 
-        char[] buffer = new char[22];
+        var buffer = new char[22];
 
-        for (int i = 0; i < count; i++)
+        for (var i = 0; i < count; i++)
         {
-            bool didWrite = NuidWriter.TryWriteNuid(buffer);
+            var didWrite = NuidWriter.TryWriteNuid(buffer);
 
             if (!didWrite)
             {
@@ -247,9 +245,9 @@ public class NuidWriterTests
     [Trait("Category", "long-running")]
     public void AllNuidsAreUnique_SmallSequentials()
     {
-        bool writeFailed = false;
-        string duplicateFailure = "";
-        Thread executionThread = new Thread(() =>
+        var writeFailed = false;
+        var duplicateFailure = string.Empty;
+        var executionThread = new Thread(() =>
         {
             Span<char> buffer = new char[22];
             for (uint seq = 0; seq < 128; seq++)
@@ -259,7 +257,7 @@ public class NuidWriterTests
                     HashSet<string> nuids = new(2048);
                     SetSequentialAndIncrement(seq, incr);
 
-                    for (int i = 0; i < 2048; i++)
+                    for (var i = 0; i < 2048; i++)
                     {
                         if (!NuidWriter.TryWriteNuid(buffer))
                         {
@@ -267,9 +265,8 @@ public class NuidWriterTests
                             return;
                         }
 
-                        //_outputHelper.WriteLine(buffer.ToString());
-
-                        string nuid = new string(buffer);
+                        // _outputHelper.WriteLine(buffer.ToString());
+                        var nuid = new string(buffer);
 
                         if (!nuids.Add(nuid))
                         {
@@ -286,16 +283,16 @@ public class NuidWriterTests
         Interlocked.MemoryBarrier();
 
         Assert.False(writeFailed);
-        Assert.Equal("", duplicateFailure);
+        Assert.Equal(string.Empty, duplicateFailure);
     }
 
     [Fact]
     [Trait("Category", "long-running")]
     public void AllNuidsAreUnique_ZeroSequential()
     {
-        bool writeFailed = false;
-        string duplicateFailure = "";
-        Thread executionThread = new Thread(() =>
+        var writeFailed = false;
+        var duplicateFailure = string.Empty;
+        var executionThread = new Thread(() =>
         {
             uint seq = 0;
             uint incr = 33;
@@ -304,7 +301,7 @@ public class NuidWriterTests
             SetSequentialAndIncrement(seq, incr);
 
             Span<char> buffer = new char[22];
-            for (int i = 0; i < 100_000_000; i++)
+            for (var i = 0; i < 100_000_000; i++)
             {
                 if (!NuidWriter.TryWriteNuid(buffer))
                 {
@@ -312,9 +309,8 @@ public class NuidWriterTests
                     return;
                 }
 
-                //_outputHelper.WriteLine(buffer.ToString());
-
-                string nuid = new string(buffer);
+                // _outputHelper.WriteLine(buffer.ToString());
+                var nuid = new string(buffer);
 
                 if (!nuids.Add(nuid))
                 {
@@ -329,24 +325,24 @@ public class NuidWriterTests
         Interlocked.MemoryBarrier();
 
         Assert.False(writeFailed);
-        Assert.Equal("", duplicateFailure);
+        Assert.Equal(string.Empty, duplicateFailure);
     }
 
     // This messes with NuidWriter's internal state and must be used
     // on separate threads (distinct NuidWriter instances) only.
     private static void SetSequentialAndIncrement(ulong sequential, ulong increment)
     {
-        bool didWrite = NuidWriter.TryWriteNuid(new char[128]);
+        var didWrite = NuidWriter.TryWriteNuid(new char[128]);
 
         Assert.True(didWrite, "didWrite");
 
-        FieldInfo fInstance = typeof(NuidWriter).GetField("t_writer", BindingFlags.Static | BindingFlags.NonPublic);
-        object instance = fInstance.GetValue(null);
+        var fInstance = typeof(NuidWriter).GetField("t_writer", BindingFlags.Static | BindingFlags.NonPublic);
+        var instance = fInstance.GetValue(null);
 
-        FieldInfo fSequential = typeof(NuidWriter).GetField("_sequential", BindingFlags.Instance | BindingFlags.NonPublic);
+        var fSequential = typeof(NuidWriter).GetField("_sequential", BindingFlags.Instance | BindingFlags.NonPublic);
         fSequential.SetValue(instance, sequential);
 
-        FieldInfo fIncrement = typeof(NuidWriter).GetField("_increment", BindingFlags.Instance | BindingFlags.NonPublic);
+        var fIncrement = typeof(NuidWriter).GetField("_increment", BindingFlags.Instance | BindingFlags.NonPublic);
         fIncrement.SetValue(instance, increment);
     }
 
@@ -362,8 +358,8 @@ public class NuidWriterTests
 
         public override void GetBytes(byte[] buffer)
         {
-            byte[] nextBytes = _bytes.Dequeue();
-            if(nextBytes.Length < buffer.Length)
+            var nextBytes = _bytes.Dequeue();
+            if (nextBytes.Length < buffer.Length)
                 throw new InvalidOperationException($"Lenght of {nameof(buffer)} is {buffer.Length}, length of {nameof(nextBytes)} is {nextBytes.Length}");
 
             Array.Copy(nextBytes, buffer, buffer.Length);


### PR DESCRIPTION
Fixes #34 

```
| Method               | Job           | Runtime       | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------------------- |-------------- |-------------- |---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| TryWriteNuid         | .NET 6.0      | .NET 6.0      | 31.00 ns | 0.365 ns | 0.305 ns | 31.06 ns |  0.99 |    0.03 |      - |         - |          NA |
| NewInbox_ShortPrefix | .NET 6.0      | .NET 6.0      | 51.74 ns | 1.078 ns | 1.476 ns | 51.90 ns |  1.64 |    0.07 | 0.0612 |     128 B |          NA |
| NewInbox_LongPrefix  | .NET 6.0      | .NET 6.0      | 76.69 ns | 1.568 ns | 2.662 ns | 76.52 ns |  2.44 |    0.12 | 0.1988 |     416 B |          NA |
| TryWriteNuid         | .NET 7.0      | .NET 7.0      | 31.61 ns | 0.661 ns | 0.926 ns | 31.21 ns |  1.00 |    0.00 |      - |         - |          NA |
| NewInbox_ShortPrefix | .NET 7.0      | .NET 7.0      | 54.38 ns | 1.116 ns | 1.044 ns | 54.72 ns |  1.74 |    0.06 | 0.0612 |     128 B |          NA |
| NewInbox_LongPrefix  | .NET 7.0      | .NET 7.0      | 77.58 ns | 0.909 ns | 0.850 ns | 77.68 ns |  2.48 |    0.08 | 0.1988 |     416 B |          NA |
| TryWriteNuid         | .NET 8.0      | .NET 8.0      | 25.50 ns | 0.499 ns | 0.390 ns | 25.58 ns |  0.82 |    0.03 |      - |         - |          NA |
| NewInbox_ShortPrefix | .NET 8.0      | .NET 8.0      | 46.84 ns | 0.986 ns | 1.317 ns | 46.94 ns |  1.48 |    0.06 | 0.0612 |     128 B |          NA |
| NewInbox_LongPrefix  | .NET 8.0      | .NET 8.0      | 66.03 ns | 0.838 ns | 0.784 ns | 66.22 ns |  2.11 |    0.07 | 0.1988 |     416 B |          NA |
| TryWriteNuid         | NativeAOT 8.0 | NativeAOT 8.0 | 25.15 ns | 0.495 ns | 0.463 ns | 25.33 ns |  0.80 |    0.03 |      - |         - |          NA |
| NewInbox_ShortPrefix | NativeAOT 8.0 | NativeAOT 8.0 | 45.00 ns | 0.945 ns | 1.843 ns | 44.25 ns |  1.44 |    0.06 | 0.0612 |     128 B |          NA |
| NewInbox_LongPrefix  | NativeAOT 8.0 | NativeAOT 8.0 | 56.34 ns | 1.139 ns | 1.066 ns | 55.62 ns |  1.80 |    0.07 | 0.1989 |     416 B |          NA |
```

Opted to go with base-62 here to follow nuid.go. base-64 (as implemented and reviewed in https://github.com/nats-io/nats.net/pull/360) would avoid some bias and be about twice as fast.