### PR TITLE
Pages fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   nuget:
+    environment: github-pages
     name: dotnet
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ permissions:
 
 jobs:
   nuget:
-    environment: github-pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     name: dotnet
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
GitHub Pages isn't working:
https://github.com/nats-io/nats.net.v2/actions/runs/6499966911/attempts/3

The only thing I can find is that the environment wasn't set: https://github.com/actions/deploy-pages#security-considerations
> The deployment should target the github-pages environment

I don't know anything about the GH environments, so not sure setting the environment on the job would affect other steps though. Assuming it won't!