### PR TITLE
Add StreamInfo request to GetStream

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
@@ -80,17 +80,19 @@ public partial class NatsJSContext
     /// Get stream information from the server and creates a NATS JetStream stream object <see cref="NatsJSStream"/>.
     /// </summary>
     /// <param name="stream">Name of the stream to retrieve.</param>
+    /// <param name="request">Stream info request options</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <returns>The NATS JetStream stream object which can be used to manage the stream.</returns>
     /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
     /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
     public async ValueTask<NatsJSStream> GetStreamAsync(
         string stream,
+        StreamInfoRequest? request = null,
         CancellationToken cancellationToken = default)
     {
-        var response = await JSRequestResponseAsync<object, StreamInfoResponse>(
+        var response = await JSRequestResponseAsync<StreamInfoRequest, StreamInfoResponse>(
             subject: $"{Opts.Prefix}.STREAM.INFO.{stream}",
-            request: null,
+            request: request,
             cancellationToken);
         return new NatsJSStream(this, response);
     }

--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -132,7 +132,7 @@ public class NatsKVContext
     {
         ValidateBucketName(bucket);
 
-        var stream = await _context.GetStreamAsync(BucketToStream(bucket), cancellationToken);
+        var stream = await _context.GetStreamAsync(BucketToStream(bucket), cancellationToken: cancellationToken);
 
         if (stream.Info.Config.MaxMsgsPerSubject < 1)
         {

--- a/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
@@ -38,20 +38,20 @@ public class ManageStreamTest
 
         // Get
         {
-            var stream = await js.GetStreamAsync("events", cancellationToken);
+            var stream = await js.GetStreamAsync("events", cancellationToken: cancellationToken);
             Assert.Equal("events", stream.Info.Config.Name);
             Assert.Equal(new[] { "events.*" }, stream.Info.Config.Subjects);
         }
 
         // Update
         {
-            var stream1 = await js.GetStreamAsync("events", cancellationToken);
+            var stream1 = await js.GetStreamAsync("events", cancellationToken: cancellationToken);
             Assert.Equal(-1, stream1.Info.Config.MaxMsgs);
 
             var stream2 = await js.UpdateStreamAsync(new StreamUpdateRequest { Name = "events", MaxMsgs = 10 }, cancellationToken);
             Assert.Equal(10, stream2.Info.Config.MaxMsgs);
 
-            var stream3 = await js.GetStreamAsync("events", cancellationToken);
+            var stream3 = await js.GetStreamAsync("events", cancellationToken: cancellationToken);
             Assert.Equal(10, stream3.Info.Config.MaxMsgs);
         }
     }


### PR DESCRIPTION
This PR adds the StreamInfoRequest to GetStream

Note: This option is not present in the nats go client. To get the required StreamInfo in the nats go client they have the `JetStreamManagement`. I added it to this method, because nats.net.v2 doesn't have the `JetStreamManagement` at the moment.

We need it to figure out the subjects inside a stream. If there is a better way, I'm happy to hear about this.