### PR TITLE
Mark StreamState Subjects as nullable

### DIFF
--- a/src/NATS.Client.JetStream/Models/StreamState.cs
+++ b/src/NATS.Client.JetStream/Models/StreamState.cs
@@ -60,7 +60,7 @@ public record StreamState
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subjects")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.IDictionary<string, long> Subjects { get; set; } = default!;
+    public System.Collections.Generic.IDictionary<string, long>? Subjects { get; set; } = null;
 
     /// <summary>
     /// The number of unique subjects held in the stream


### PR DESCRIPTION
This PR marks the Subjects property as nullable. Subjects gets only set when StreamInfo has a subjects filter set and nats is initialized.