### PR TITLE
JetStream consume idle heartbeat fix

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -38,6 +38,7 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
 
     private int _pongCount;
     private bool _isDisposed;
+    private int _connectionState;
 
     // when reconnect, make new instance.
     private ISocketConnection? _socket;
@@ -84,7 +85,11 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
 
     public NatsOpts Opts { get; }
 
-    public NatsConnectionState ConnectionState { get; private set; }
+    public NatsConnectionState ConnectionState
+    {
+        get => (NatsConnectionState)Volatile.Read(ref _connectionState);
+        private set => Interlocked.Exchange(ref _connectionState, (int)value);
+    }
 
     public INatsServerInfo? ServerInfo => WritableServerInfo; // server info is set when received INFO
 

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -105,14 +105,17 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
                     return;
                 }
 
-                self.Pull("heartbeat-timeout", self._maxMsgs, self._maxBytes);
-                self.ResetPending();
-                if (self._debug)
+                if (self.Connection.ConnectionState == NatsConnectionState.Open)
                 {
-                    self._logger.LogDebug(
-                        NatsJSLogEvents.IdleTimeout,
-                        "Idle heartbeat timeout after {Timeout}ns",
-                        self._idle);
+                    self.Pull("heartbeat-timeout", self._maxMsgs, self._maxBytes);
+                    self.ResetPending();
+                    if (self._debug)
+                    {
+                        self._logger.LogDebug(
+                            NatsJSLogEvents.IdleTimeout,
+                            "Idle heartbeat timeout after {Timeout}ns",
+                            self._idle);
+                    }
                 }
             },
             this,
@@ -156,7 +159,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
             cancellationToken);
     }
 
-    public void ResetHeartbeatTimer() => _timer.Change(_hbTimeout, Timeout.Infinite);
+    public void ResetHeartbeatTimer() => _timer.Change(_hbTimeout, _hbTimeout);
 
     public override async ValueTask DisposeAsync()
     {


### PR DESCRIPTION
Keep the idle heartbeat timer ticking so if all else fails, it will try to send pull requests as long as we have an open connection. We also made a preventive change to connection state management making it thread safe since we suspect there may be race conditions on ARM processors for example.

(Issue was found during failground testing: consumer stopped pulling after about 20 hours)