### PR TITLE
Async iterator subscription memory fix

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.Subscribe.cs
+++ b/src/NATS.Client.Core/NatsConnection.Subscribe.cs
@@ -1,22 +1,43 @@
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
 namespace NATS.Client.Core;
 
 public partial class NatsConnection
 {
+    // Keep subscription alive until the channel reader completes.
+    // Otherwise subscription is collected because subscription manager
+    // only holds a weak reference to it.
+    private readonly ConcurrentDictionary<long, NatsSubBase> _subAnchor = new();
+    private long _subAnchorId;
+
     /// <inheritdoc />
     public async IAsyncEnumerable<NatsMsg<T>> SubscribeAsync<T>(string subject, string? queueGroup = default, INatsDeserialize<T>? serializer = default, NatsSubOpts? opts = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await using var sub = await SubscribeInternalAsync(subject, queueGroup, serializer, opts, cancellationToken).ConfigureAwait(false);
-
-        // We don't cancel the channel reader here because we want to keep reading until the subscription
-        // channel writer completes so that messages left in the channel can be consumed before exit the loop.
-        while (await sub.Msgs.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
+        var anchor = Interlocked.Increment(ref _subAnchorId);
+        try
         {
-            while (sub.Msgs.TryRead(out var msg))
+            serializer ??= Opts.SerializerRegistry.GetDeserializer<T>();
+
+            await using var sub = new NatsSub<T>(this, SubscriptionManager.GetManagerFor(subject), subject, queueGroup, opts, serializer, cancellationToken);
+
+            _subAnchor[anchor] = sub;
+
+            await SubAsync(sub, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // We don't cancel the channel reader here because we want to keep reading until the subscription
+            // channel writer completes so that messages left in the channel can be consumed before exit the loop.
+            while (await sub.Msgs.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
             {
-                yield return msg;
+                while (sub.Msgs.TryRead(out var msg))
+                {
+                    yield return msg;
+                }
             }
+        }
+        finally
+        {
+            _subAnchor.TryRemove(anchor, out _);
         }
     }
 

--- a/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
+++ b/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
@@ -35,4 +35,78 @@ public class NatsSubTests
             server.DisposeAsync().GetAwaiter().GetResult();
         }
     }
+
+    [Test]
+    public void Subscription_should_not_be_collected_when_in_async_enumerator()
+    {
+        var server = NatsServer.Start();
+        try
+        {
+            var nats = server.CreateClientConnection();
+
+            var sync = 0;
+
+            var sub = Task.Run(async () =>
+            {
+                var count = 0;
+                await foreach (var msg in nats.SubscribeAsync<string>("foo.*"))
+                {
+                    if (msg.Subject == "foo.sync")
+                    {
+                        Interlocked.Increment(ref sync);
+                        continue;
+                    }
+
+                    if (++count == 10)
+                        break;
+                }
+            });
+
+
+            var pub = Task.Run(async () =>
+            {
+                while (Volatile.Read(ref sync) == 0)
+                {
+                    await nats.PublishAsync("foo.sync", "sync");
+                }
+
+                for (var i = 0; i < 10; i++)
+                {
+                    GC.Collect();
+
+                    dotMemory.Check(memory =>
+                    {
+                        var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
+                        Assert.That(count, Is.EqualTo(1), "Alive");
+                    });
+
+                    await nats.PublishAsync("foo.data", "data");
+                }
+            });
+
+            var waitPub = Task.WaitAll(new[] { pub }, TimeSpan.FromSeconds(10));
+            if (!waitPub)
+            {
+                Assert.Fail("Timed out waiting for pub task to complete");
+            }
+
+            var waitSub = Task.WaitAll(new[] { sub }, TimeSpan.FromSeconds(10));
+            if (!waitSub)
+            {
+                Assert.Fail("Timed out waiting for sub task to complete");
+            }
+
+            GC.Collect();
+
+            dotMemory.Check(memory =>
+            {
+                var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
+                Assert.That(count, Is.EqualTo(0), "Collected");
+            });
+        }
+        finally
+        {
+            server.DisposeAsync().GetAwaiter().GetResult();
+        }
+    }
 }


### PR DESCRIPTION
The issue was happening with Perf tests hanging. It turns out when subscription was handled within async iterator we loose a reference to the subscription potentially because it's in a using as well. This solution makes sure the connection object will keep a reference so subscription object won't be collected because of the weak ref in the subscription manager. Also we don't need to worry about disposing the subscription now because as soon as the loop exits it will be disposed.