### PR TITLE
TLS validation error logging on connection

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -262,7 +262,7 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
                 }
                 else
                 {
-                    var conn = new TcpConnection();
+                    var conn = new TcpConnection(_logger);
                     await conn.ConnectAsync(target.Host, target.Port, Opts.ConnectTimeout).ConfigureAwait(false);
                     _socket = conn;
 
@@ -484,7 +484,7 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
                     }
                     else
                     {
-                        var conn = new TcpConnection();
+                        var conn = new TcpConnection(_logger);
                         await conn.ConnectAsync(url.Host, url.Port, Opts.ConnectTimeout).ConfigureAwait(false);
                         _socket = conn;
 


### PR DESCRIPTION
When connection fails because of SSL validation checks the exception doesn't tell you that (just says could not connect). If the user enables logging then they'd at least be able to see if the connection failed because of TLS validation errors and why.