### PR TITLE
JetStream ordered consume stability fixes

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.Subscribe.cs
+++ b/src/NATS.Client.Core/NatsConnection.Subscribe.cs
@@ -14,30 +14,21 @@ public partial class NatsConnection
     /// <inheritdoc />
     public async IAsyncEnumerable<NatsMsg<T>> SubscribeAsync<T>(string subject, string? queueGroup = default, INatsDeserialize<T>? serializer = default, NatsSubOpts? opts = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var anchor = Interlocked.Increment(ref _subAnchorId);
-        try
+        serializer ??= Opts.SerializerRegistry.GetDeserializer<T>();
+
+        await using var sub = new NatsSub<T>(this, SubscriptionManager.GetManagerFor(subject), subject, queueGroup, opts, serializer, cancellationToken);
+        using var anchor = RegisterSubAnchor(sub);
+
+        await SubAsync(sub, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // We don't cancel the channel reader here because we want to keep reading until the subscription
+        // channel writer completes so that messages left in the channel can be consumed before exit the loop.
+        while (await sub.Msgs.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
         {
-            serializer ??= Opts.SerializerRegistry.GetDeserializer<T>();
-
-            await using var sub = new NatsSub<T>(this, SubscriptionManager.GetManagerFor(subject), subject, queueGroup, opts, serializer, cancellationToken);
-
-            _subAnchor[anchor] = sub;
-
-            await SubAsync(sub, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            // We don't cancel the channel reader here because we want to keep reading until the subscription
-            // channel writer completes so that messages left in the channel can be consumed before exit the loop.
-            while (await sub.Msgs.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
+            while (sub.Msgs.TryRead(out var msg))
             {
-                while (sub.Msgs.TryRead(out var msg))
-                {
-                    yield return msg;
-                }
+                yield return msg;
             }
-        }
-        finally
-        {
-            _subAnchor.TryRemove(anchor, out _);
         }
     }
 
@@ -47,5 +38,31 @@ public partial class NatsConnection
         var sub = new NatsSub<T>(this, SubscriptionManager.GetManagerFor(subject), subject, queueGroup, opts, serializer, cancellationToken);
         await SubAsync(sub, cancellationToken).ConfigureAwait(false);
         return sub;
+    }
+
+    /// <summary>
+    /// Make sure subscription is not collected until the end of the scope.
+    /// </summary>
+    /// <param name="sub">Subscription object</param>
+    /// <returns>Disposable</returns>
+    /// <remarks>
+    /// We must keep subscription alive until the end of its scope especially in async iterators.
+    /// Otherwise subscription is collected because subscription manager only holds a weak reference to it.
+    /// </remarks>
+    internal IDisposable RegisterSubAnchor(NatsSubBase sub) => new SubAnchor(this, sub);
+
+    internal class SubAnchor : IDisposable
+    {
+        private readonly NatsConnection _nats;
+        private readonly long _anchor;
+
+        public SubAnchor(NatsConnection nats, NatsSubBase sub)
+        {
+            _nats = nats;
+            _anchor = Interlocked.Increment(ref _nats._subAnchorId);
+            _nats._subAnchor[_anchor] = sub;
+        }
+
+        public void Dispose() => _nats._subAnchor.TryRemove(_anchor, out _);
     }
 }

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
@@ -1,0 +1,408 @@
+using System.Buffers;
+using System.Text;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using NATS.Client.Core;
+using NATS.Client.Core.Commands;
+using NATS.Client.JetStream.Models;
+
+namespace NATS.Client.JetStream.Internal;
+
+internal class NatsJSOrderedConsume<TMsg> : NatsSubBase
+{
+    private readonly ILogger _logger;
+    private readonly bool _debug;
+    private readonly Channel<NatsJSMsg<TMsg>> _userMsgs;
+    private readonly Channel<PullRequest> _pullRequests;
+    private readonly NatsJSContext _context;
+    private readonly string _stream;
+    private readonly string _consumer;
+    private readonly CancellationToken _cancellationToken;
+    private readonly INatsDeserialize<TMsg> _serializer;
+    private readonly Timer _timer;
+    private readonly Task _pullTask;
+
+    private readonly long _maxMsgs;
+    private readonly long _expires;
+    private readonly long _idle;
+    private readonly long _hbTimeout;
+    private readonly long _thresholdMsgs;
+    private readonly long _maxBytes;
+    private readonly long _thresholdBytes;
+
+    private readonly object _pendingGate = new();
+    private long _pendingMsgs;
+    private long _pendingBytes;
+    private int _disposed;
+
+    public NatsJSOrderedConsume(
+        long maxMsgs,
+        long thresholdMsgs,
+        long maxBytes,
+        long thresholdBytes,
+        TimeSpan expires,
+        TimeSpan idle,
+        NatsJSContext context,
+        string stream,
+        string consumer,
+        string subject,
+        string? queueGroup,
+        INatsDeserialize<TMsg> serializer,
+        NatsSubOpts? opts,
+        CancellationToken cancellationToken)
+        : base(context.Connection, context.Connection.SubscriptionManager, subject, queueGroup, opts)
+    {
+        _cancellationToken = cancellationToken;
+        _logger = Connection.Opts.LoggerFactory.CreateLogger<NatsJSConsume<TMsg>>();
+        _debug = _logger.IsEnabled(LogLevel.Debug);
+        _context = context;
+        _stream = stream;
+        _consumer = consumer;
+        _serializer = serializer;
+
+        _maxMsgs = maxMsgs;
+        _thresholdMsgs = thresholdMsgs;
+        _maxBytes = maxBytes;
+        _thresholdBytes = thresholdBytes;
+        _expires = expires.ToNanos();
+        _idle = idle.ToNanos();
+        _hbTimeout = (int)(idle * 2).TotalMilliseconds;
+
+        if (_debug)
+        {
+            _logger.LogDebug(
+                NatsJSLogEvents.Config,
+                "Consume setup {@Config}",
+                new
+                {
+                    maxMsgs,
+                    thresholdMsgs,
+                    maxBytes,
+                    thresholdBytes,
+                    expires,
+                    idle,
+                    _hbTimeout,
+                });
+        }
+
+        _timer = new Timer(
+            static state =>
+            {
+                var self = (NatsJSOrderedConsume<TMsg>)state!;
+                self._logger.LogWarning("Idle heartbeat timeout");
+                self._userMsgs.Writer.TryComplete(new NatsJSTimeoutException("idle-heartbeat"));
+            },
+            this,
+            Timeout.Infinite,
+            Timeout.Infinite);
+
+        // Keep user channel small to avoid blocking the user code
+        // when disposed otherwise channel reader will continue delivering messages
+        // if there are messages queued up already. This channel is used to pass messages
+        // to the user from the subscription channel (which should be set to a
+        // sufficiently large value to avoid blocking socket reads in the
+        // NATS connection).
+        _userMsgs = Channel.CreateBounded<NatsJSMsg<TMsg>>(1);
+        Msgs = _userMsgs.Reader;
+
+        // Capacity as 1 is enough here since it's used for signaling only.
+        _pullRequests = Channel.CreateBounded<PullRequest>(1);
+        _pullTask = Task.Run(PullLoop);
+
+        ResetPending();
+
+        _context.Connection.ConnectionDisconnected += ConnectionOnConnectionDisconnected;
+    }
+
+    public ChannelReader<NatsJSMsg<TMsg>> Msgs { get; }
+
+    public ValueTask CallMsgNextAsync(string origin, ConsumerGetnextRequest request, CancellationToken cancellationToken = default)
+    {
+        if (_cancellationToken.IsCancellationRequested)
+            return default;
+
+        if (_debug)
+        {
+            _logger.LogDebug("Sending pull request for {Origin} {Msgs}, {Bytes}", origin, request.Batch, request.MaxBytes);
+        }
+
+        return Connection.PubModelAsync(
+            subject: $"{_context.Opts.Prefix}.CONSUMER.MSG.NEXT.{_stream}.{_consumer}",
+            data: request,
+            serializer: NatsJSJsonSerializer<ConsumerGetnextRequest>.Default,
+            replyTo: Subject,
+            headers: default,
+            cancellationToken);
+    }
+
+    public void ResetHeartbeatTimer() => _timer.Change(_hbTimeout, Timeout.Infinite);
+
+    public override async ValueTask DisposeAsync()
+    {
+        Interlocked.Exchange(ref _disposed, 1);
+
+        _context.Connection.ConnectionDisconnected -= ConnectionOnConnectionDisconnected;
+
+        await base.DisposeAsync().ConfigureAwait(false);
+        await _pullTask.ConfigureAwait(false);
+        await _timer.DisposeAsync().ConfigureAwait(false);
+    }
+
+    internal override IEnumerable<ICommand> GetReconnectCommands(int sid)
+    {
+        // Override normal subscription behavior to resubscribe on reconnect
+       yield break;
+    }
+
+    protected override async ValueTask ReceiveInternalAsync(
+        string subject,
+        string? replyTo,
+        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> payloadBuffer)
+    {
+        ResetHeartbeatTimer();
+
+        if (subject == Subject)
+        {
+            if (headersBuffer.HasValue)
+            {
+                var headers = new NatsHeaders();
+                if (Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(headersBuffer.Value), headers))
+                {
+                    if (_maxBytes == 0 && headers.TryGetValue("Nats-Pending-Messages", out var natsPendingMsgs))
+                    {
+                        if (long.TryParse(natsPendingMsgs, out var pendingMsgs))
+                        {
+                            lock (_pendingGate)
+                            {
+                                if (_debug)
+                                {
+                                    _logger.LogDebug(
+                                        NatsJSLogEvents.PendingCount,
+                                        "Header pending messages current {Pending}",
+                                        _pendingMsgs);
+                                }
+
+                                _pendingMsgs -= pendingMsgs;
+                                if (_pendingMsgs < 0)
+                                    _pendingMsgs = 0;
+
+                                if (_debug)
+                                {
+                                    _logger.LogDebug(
+                                        NatsJSLogEvents.PendingCount,
+                                        "Header pending messages {Header} {Pending}",
+                                        natsPendingMsgs,
+                                        _pendingMsgs);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            _logger.LogError(NatsJSLogEvents.PendingCount, "Can't parse Nats-Pending-Messages {Header}", natsPendingMsgs);
+                        }
+                    }
+
+                    if (_maxBytes > 0 && headers.TryGetValue("Nats-Pending-Bytes", out var natsPendingBytes))
+                    {
+                        if (long.TryParse(natsPendingBytes, out var pendingBytes))
+                        {
+                            lock (_pendingGate)
+                            {
+                                if (_debug)
+                                {
+                                    _logger.LogDebug(NatsJSLogEvents.PendingCount, "Header pending bytes current {Pending}", _pendingBytes);
+                                }
+
+                                _pendingBytes -= pendingBytes;
+                                if (_pendingBytes < 0)
+                                    _pendingBytes = 0;
+
+                                if (_debug)
+                                {
+                                    _logger.LogDebug(NatsJSLogEvents.PendingCount, "Header pending bytes {Header} {Pending}", natsPendingBytes, _pendingBytes);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            _logger.LogError(NatsJSLogEvents.PendingCount, "Can't parse Nats-Pending-Bytes {Header}", natsPendingBytes);
+                        }
+                    }
+
+                    if (headers is { Code: 408, Message: NatsHeaders.Messages.RequestTimeout })
+                    {
+                    }
+                    else if (headers is { Code: 409, Message: NatsHeaders.Messages.MessageSizeExceedsMaxBytes })
+                    {
+                    }
+                    else if (headers is { Code: 100, Message: NatsHeaders.Messages.IdleHeartbeat })
+                    {
+                    }
+                    else if (headers.Code == 409 && string.Equals(headers.MessageText, "Leadership Change", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogDebug(NatsJSLogEvents.LeadershipChange, "Leadership Change");
+                        lock (_pendingGate)
+                        {
+                            _pendingBytes = 0;
+                            _pendingMsgs = 0;
+                        }
+                    }
+                    else if (headers.HasTerminalJSError())
+                    {
+                        _userMsgs.Writer.TryComplete(new NatsJSProtocolException(headers.Code, headers.Message, headers.MessageText));
+                        EndSubscription(NatsSubEndReason.JetStreamError);
+                    }
+                    else
+                    {
+                        if (_debug)
+                        {
+                            _logger.LogDebug(NatsJSLogEvents.ProtocolMessage, "Protocol message: {Code} {Description}", headers.Code, headers.MessageText);
+                        }
+                    }
+                }
+                else
+                {
+                    _logger.LogError(
+                        NatsJSLogEvents.Headers,
+                        "Can't parse headers: {HeadersBuffer}",
+                        Encoding.ASCII.GetString(headersBuffer.Value.ToArray()));
+                    throw new NatsJSException("Can't parse headers");
+                }
+            }
+            else
+            {
+                throw new NatsJSException("No header found");
+            }
+        }
+        else
+        {
+            var msg = new NatsJSMsg<TMsg>(
+                NatsMsg<TMsg>.Build(
+                    subject,
+                    replyTo,
+                    headersBuffer,
+                    payloadBuffer,
+                    Connection,
+                    Connection.HeaderParser,
+                    _serializer),
+                _context);
+
+            lock (_pendingGate)
+            {
+                if (_pendingMsgs > 0)
+                    _pendingMsgs--;
+            }
+
+            if (_maxBytes > 0)
+            {
+                if (_debug)
+                    _logger.LogDebug(NatsJSLogEvents.MessageProperty, "Message size {Size}", msg.Size);
+
+                lock (_pendingGate)
+                {
+                    _pendingBytes -= msg.Size;
+                }
+            }
+
+            // Stop feeding the user if we are disposed.
+            // We need to exit as soon as possible.
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                // We can't pass cancellation token here because we need to hand
+                // the message to the user to be processed. Writer will be completed
+                // when the user calls Stop() or when the subscription is closed.
+                await _userMsgs.Writer.WriteAsync(msg).ConfigureAwait(false);
+            }
+        }
+
+        CheckPending();
+    }
+
+    protected override void TryComplete()
+    {
+        _pullRequests.Writer.TryComplete();
+        _userMsgs.Writer.TryComplete();
+    }
+
+    private void ConnectionOnConnectionDisconnected(object? sender, string e)
+    {
+        _logger.LogWarning("Disconnected {Reason}", e);
+        _userMsgs.Writer.TryComplete(new NatsJSConnectionException(e));
+    }
+
+    private void ResetPending()
+    {
+        lock (_pendingGate)
+        {
+            _pendingMsgs = _maxMsgs;
+            _pendingBytes = _maxBytes;
+        }
+    }
+
+    private void CheckPending()
+    {
+        lock (_pendingGate)
+        {
+            if (_maxBytes > 0 && _pendingBytes <= _thresholdBytes)
+            {
+                if (_debug)
+                    _logger.LogDebug(NatsJSLogEvents.PendingCount, "Check pending bytes {Pending}, {MaxBytes}", _pendingBytes, _maxBytes);
+
+                Pull("chk-bytes", _maxMsgs, _maxBytes - _pendingBytes);
+                ResetPending();
+            }
+            else if (_maxBytes == 0 && _pendingMsgs <= _thresholdMsgs && _pendingMsgs < _maxMsgs)
+            {
+                if (_debug)
+                    _logger.LogDebug(NatsJSLogEvents.PendingCount, "Check pending messages {Pending}, {MaxMsgs}", _pendingMsgs, _maxMsgs);
+
+                Pull("chk-msgs", _maxMsgs - _pendingMsgs, 0);
+                ResetPending();
+            }
+        }
+    }
+
+    private void CompleteStop()
+    {
+        if (_debug)
+        {
+            _logger.LogDebug(NatsJSLogEvents.Stopping, "No more pull requests or messages in-flight, stopping");
+        }
+
+        // Schedule on the thread pool to avoid potential deadlocks.
+        ThreadPool.UnsafeQueueUserWorkItem(
+            state =>
+            {
+                var self = (NatsJSOrderedConsume<TMsg>)state!;
+                self._userMsgs.Writer.TryComplete();
+                self.EndSubscription(NatsSubEndReason.None);
+            },
+            this);
+    }
+
+    private void Pull(string origin, long batch, long maxBytes) => _pullRequests.Writer.TryWrite(new PullRequest
+    {
+        Request = new ConsumerGetnextRequest
+        {
+            Batch = batch,
+            MaxBytes = maxBytes,
+            IdleHeartbeat = _idle,
+            Expires = _expires,
+        },
+        Origin = origin,
+    });
+
+    private async Task PullLoop()
+    {
+        await foreach (var pr in _pullRequests.Reader.ReadAllAsync().ConfigureAwait(false))
+        {
+            var origin = $"pull-loop({pr.Origin})";
+            await CallMsgNextAsync(origin, pr.Request).ConfigureAwait(false);
+            if (_debug)
+            {
+                _logger.LogDebug(NatsJSLogEvents.PullRequest, "Pull request issued for {Origin} {Batch}, {MaxBytes}", origin, pr.Request.Batch, pr.Request.MaxBytes);
+            }
+        }
+    }
+}

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -61,6 +61,10 @@ public class NatsJSConsumer : INatsJSConsumer
     {
         opts ??= _context.Opts.DefaultConsumeOpts;
         await using var cc = await ConsumeInternalAsync<T>(serializer, opts, cancellationToken).ConfigureAwait(false);
+
+        // Keep subscription alive (since it's a wek ref in subscription manager) until we're done.
+        using var anchor = _context.Connection.RegisterSubAnchor(cc);
+
         await foreach (var jsMsg in cc.Msgs.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return jsMsg;

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -202,6 +202,7 @@ public partial class NatsJSContext
                     subject: subject,
                     data: request,
                     headers: default,
+                    replyOpts: new NatsSubOpts { Timeout = Connection.Opts.RequestTimeout },
                     requestSerializer: NatsJSJsonSerializer<TRequest>.Default,
                     replySerializer: NatsJSErrorAwareJsonSerializer<TResponse>.Default,
                     cancellationToken: cancellationTimer.Token)
@@ -233,7 +234,7 @@ public partial class NatsJSContext
                 throw sb.Exception;
             }
 
-            throw new NatsJSException("No response received");
+            throw new NatsJSApiNoResponseException();
         }
         finally
         {

--- a/src/NATS.Client.JetStream/NatsJSException.cs
+++ b/src/NATS.Client.JetStream/NatsJSException.cs
@@ -99,3 +99,29 @@ public class NatsJSPublishNoResponseException : NatsJSException
     {
     }
 }
+
+public class NatsJSApiNoResponseException : NatsJSException
+{
+    public NatsJSApiNoResponseException()
+        : base("No API response received from the server")
+    {
+    }
+}
+
+public class NatsJSTimeoutException : NatsJSException
+{
+    public NatsJSTimeoutException(string type)
+        : base($"{type} timed out") =>
+        Type = type;
+
+    public string Type { get; }
+}
+
+public class NatsJSConnectionException : NatsJSException
+{
+    public NatsJSConnectionException(string reason)
+        : base($"Connection error: {reason}") =>
+        Reason = reason;
+
+    public string Reason { get; }
+}

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -74,6 +74,9 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
 
                 await using (var cc = await consumer.OrderedConsumeInternalAsync(serializer, opts, cancellationToken))
                 {
+                    // Keep subscription alive (since it's a wek ref in subscription manager) until we're done.
+                    using var anchor = _context.Connection.RegisterSubAnchor(cc);
+
                     while (true)
                     {
                         // We have to check every call to WaitToReadAsync and TryRead for

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -281,7 +281,23 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
             }
         }
 
-        var info = await _context.CreateOrderedConsumerInternalAsync(_stream, consumerOpts, cancellationToken);
+        ConsumerInfo info;
+        for (var i = 0; ; i++)
+        {
+            try
+            {
+                info = await _context.CreateOrderedConsumerInternalAsync(_stream, consumerOpts, cancellationToken);
+                break;
+            }
+            catch (NatsJSApiNoResponseException)
+            {
+            }
+
+            if (i == _opts.MaxResetAttempts)
+            {
+                throw new NatsJSException("Maximum number of create attempts reached.");
+            }
+        }
 
         Info = info;
 

--- a/tests/NATS.Client.Core.MemoryTests/NatsConsumeTests.cs
+++ b/tests/NATS.Client.Core.MemoryTests/NatsConsumeTests.cs
@@ -22,7 +22,7 @@ public class NatsConsumeTests
             {
                 await js.CreateStreamAsync("s1", new[] { "s1.*" });
 
-                var consumer = await js.CreateOrderedConsumerAsync("s1");
+                var consumer = await js.CreateConsumerAsync("s1", "c1");
 
                 var count = 0;
                 await foreach (var msg in consumer.ConsumeAsync<int>(opts: new NatsJSConsumeOpts { MaxMsgs = 100 }))
@@ -76,6 +76,84 @@ public class NatsConsumeTests
             dotMemory.Check(memory =>
             {
                 var count = memory.GetObjects(where => where.Type.Is<NatsJSConsume<int>>()).ObjectsCount;
+                Assert.That(count, Is.EqualTo(0), "Collected");
+            });
+        }
+        finally
+        {
+            server.DisposeAsync().GetAwaiter().GetResult();
+        }
+    }
+
+    [Test]
+    public void Subscription_should_not_be_collected_when_in_ordered_consume_async_enumerator()
+    {
+        var server = NatsServer.StartJS();
+        try
+        {
+            var nats = server.CreateClientConnection();
+            var js = new NatsJSContext(nats);
+
+            var sync = new TaskCompletionSource();
+
+            var sub = Task.Run(async () =>
+            {
+                await js.CreateStreamAsync("s1", new[] { "s1.*" });
+
+                var consumer = await js.CreateOrderedConsumerAsync("s1");
+
+                var count = 0;
+                await foreach (var msg in consumer.ConsumeAsync<int>(opts: new NatsJSConsumeOpts { MaxMsgs = 100 }))
+                {
+                    if (msg.Data == -1)
+                    {
+                        sync.SetResult();
+                        continue;
+                    }
+
+                    if (++count == 20)
+                        break;
+                }
+            });
+
+            var pub = Task.Run(async () =>
+            {
+                var ack1 = await js.PublishAsync("s1.x", -1);
+                ack1.EnsureSuccess();
+                await sync.Task;
+
+                for (var i = 0; i < 20; i++)
+                {
+                    GC.Collect();
+
+                    dotMemory.Check(memory =>
+                    {
+                        var count = memory.GetObjects(where => where.Type.Is<NatsJSOrderedConsume<int>>()).ObjectsCount;
+                        Assert.That(count, Is.EqualTo(1), $"Alive {i}");
+                    });
+
+                    var ack = await js.PublishAsync("s1.x", i);
+                    ack.EnsureSuccess();
+                }
+            });
+
+            var waitPub = Task.WaitAll(new[] { pub }, TimeSpan.FromSeconds(30));
+            if (!waitPub)
+            {
+                Assert.Fail("Timed out waiting for pub task to complete");
+            }
+
+            var waitSub = Task.WaitAll(new[] { sub }, TimeSpan.FromSeconds(30));
+            if (!waitSub)
+            {
+                Assert.Fail("Timed out waiting for sub task to complete");
+            }
+
+            GC.Collect();
+
+            dotMemory.Check(memory =>
+            {
+                var count = memory.GetObjects(where => where.Type.Is<NatsJSOrderedConsume<int>>()).ObjectsCount;
                 Assert.That(count, Is.EqualTo(0), "Collected");
             });
         }


### PR DESCRIPTION
Because ordered consume operations use ephemeral consumers it's important to be able to create new consumers when things go wrong. There are two major events that might strongly indicate we won't be able to find our consumer on the server: disconnects and idle heartbeat timeouts.

With this approach introduced with this fix, we recreate the consumer on server disconnects and idle heartbeat timeouts, making sure the consumer can carry on from where it's left off (sequence state is maintained when this happens).

Justification for large code duplication: NatsJSOrderedConsume.cs is a copy of NatsJSConsume.cs subscription class. Reason for this is to maintain stability of the normal consumer since the main behaviour is fairly different. There is also a chance the behaviours might diverge even greater as we discover other issues. We may consider to merge these classes in a tidy-up effort later on.

We also introduced a general timeout (same as connection request timeout) for all JetStream API calls. We needed this because the consumer deletion process was sometimes hanging due to the server receiving the request being killed and never sending a response back. Before this we were relying on the CommandTimeout (which is 1 minute by default) to kick in. Now we use RequestTimeout (5 seconds by default) on the subscription waiting for the reply.