### PR TITLE
Test flapper fixes

### DIFF
--- a/tests/NATS.Client.JetStream.Tests/ConsumerNextTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerNextTest.cs
@@ -11,11 +11,12 @@ public class ConsumerNextTest
     [Fact]
     public async Task Next_test()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-
         await using var server = NatsServer.StartJS();
         await using var nats = server.CreateClientConnection();
         var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
         await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
         var consumer = await js.CreateConsumerAsync("s1", "c1", cancellationToken: cts.Token);
 

--- a/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
@@ -44,10 +44,11 @@ public class OrderedConsumerTest
     [Fact]
     public async Task Consume_reconnect_publish()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var server = NatsServer.StartJS();
         await using var nats = server.CreateClientConnection();
         var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         var stream = await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
 


### PR DESCRIPTION
Some tests are failing because of cancellation timeouts. Moved timeout tokens after server creations since that might take longer when running test suits.