### PR TITLE
JetStream double ACK and NAK delay

### DIFF
--- a/src/NATS.Client.JetStream/Internal/NatsJSConstants.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConstants.cs
@@ -6,7 +6,7 @@ namespace NATS.Client.JetStream.Internal;
 internal static class NatsJSConstants
 {
     public static readonly ReadOnlySequence<byte> Ack = new(Encoding.ASCII.GetBytes("+ACK"));
-    public static readonly ReadOnlySequence<byte> Nack = new(Encoding.ASCII.GetBytes("-NAK"));
+    public static readonly ReadOnlySequence<byte> Nak = new(Encoding.ASCII.GetBytes("-NAK"));
     public static readonly ReadOnlySequence<byte> AckProgress = new(Encoding.ASCII.GetBytes("+WPI"));
     public static readonly ReadOnlySequence<byte> AckTerminate = new(Encoding.ASCII.GetBytes("+TERM"));
 }

--- a/tests/NATS.Client.JetStream.Tests/DoubleAckNakDelayTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/DoubleAckNakDelayTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Text.RegularExpressions;
+using NATS.Client.Core.Tests;
+
+namespace NATS.Client.JetStream.Tests;
+
+public class DoubleAckNakDelayTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public DoubleAckNakDelayTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task Double_ack_received_messages()
+    {
+        await using var server = NatsServer.StartJS();
+        var (nats1, proxy) = server.CreateProxiedClientConnection();
+        await using var nats = nats1;
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        var consumer = await js.CreateConsumerAsync("s1", "c1", cancellationToken: cts.Token);
+
+        var ack = await js.PublishAsync("s1.foo", 42, cancellationToken: cts.Token);
+        ack.EnsureSuccess();
+        var next = await consumer.NextAsync<int>(cancellationToken: cts.Token);
+        if (next is { } msg)
+        {
+            await msg.AckAsync(new AckOpts(DoubleAck: true), cts.Token);
+            Assert.Equal(42, msg.Data);
+
+            await Retry.Until("seen ACK", () => proxy.Frames.Any(f => f.Message.StartsWith("PUB $JS.ACK")));
+
+            var ackFrame = proxy.Frames.Single(f => f.Message.StartsWith("PUB $JS.ACK"));
+            var inbox = Regex.Match(ackFrame.Message, @"\s(_INBOX\.\w+\.\w+)\s+\d").Groups[1].Value;
+
+            await Retry.Until("seen ACK-ACK", () => proxy.Frames.Any(f => f.Message.StartsWith($"MSG {inbox}")));
+        }
+        else
+        {
+            Assert.Fail("No message received");
+        }
+    }
+
+    [Fact]
+    public async Task Delay_nak_received_messages()
+    {
+        await using var server = NatsServer.StartJS();
+        var (nats1, proxy) = server.CreateProxiedClientConnection();
+        await using var nats = nats1;
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        var consumer = await js.CreateConsumerAsync("s1", "c1", cancellationToken: cts.Token);
+
+        var ack = await js.PublishAsync("s1.foo", 42, cancellationToken: cts.Token);
+        ack.EnsureSuccess();
+        var next = await consumer.NextAsync<int>(cancellationToken: cts.Token);
+        if (next is { } msg)
+        {
+            await msg.NakAsync(delay: TimeSpan.FromSeconds(123), cancellationToken: cts.Token);
+            Assert.Equal(42, msg.Data);
+
+            await Retry.Until("seen ACK", () => proxy.Frames.Any(f => f.Message.StartsWith("PUB $JS.ACK")));
+
+            var nakFrame = proxy.Frames.Single(f => f.Message.StartsWith("PUB $JS.ACK"));
+
+            Assert.Matches(@"-NAK\s+\{\s*""delay""\s*:\s*123000000000\s*\}", nakFrame.Message);
+        }
+        else
+        {
+            Assert.Fail("No message received");
+        }
+    }
+}


### PR DESCRIPTION
* Messages received by the consumer can be acknowledged optionally asking the server acknowledging the message acknowledgment.
* Messages can be 'rejected' (-NAK) with a delay.