### PR TITLE
JetStream enum PascalCase serializer

### DIFF
--- a/NATS.Client.sln.DotSettings
+++ b/NATS.Client.sln.DotSettings
@@ -9,4 +9,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HMSG/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HPUB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Msgs/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nuid/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nuid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Workqueue/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/sandbox/Example.JetStream.PullConsumer/Program.cs
+++ b/sandbox/Example.JetStream.PullConsumer/Program.cs
@@ -19,7 +19,7 @@ await using var nats = new NatsConnection(options);
 
 var js = new NatsJSContext(nats);
 
-var consumer = await js.CreateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1", AckPolicy = ConsumerConfigAckPolicy.@explicit });
+var consumer = await js.CreateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1", AckPolicy = ConsumerConfigAckPolicy.Explicit });
 
 var idle = TimeSpan.FromSeconds(5);
 var expires = TimeSpan.FromSeconds(10);

--- a/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
@@ -7,7 +7,23 @@ namespace NATS.Client.JetStream.Internal;
 
 internal static class NatsJSJsonSerializer<T>
 {
+#if NET6_0
     public static readonly INatsSerializer<T> Default = new NatsJsonContextSerializer<T>(NatsJSJsonSerializerContext.Default);
+#else
+    public static readonly INatsSerializer<T> Default = new NatsJsonContextSerializer<T>(new NatsJSJsonSerializerContext(new JsonSerializerOptions
+    {
+        Converters =
+        {
+            new JsonStringEnumConverter<ConsumerConfigDeliverPolicy>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<ConsumerConfigAckPolicy>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<ConsumerConfigReplayPolicy>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<StreamConfigCompression>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<StreamConfigDiscard>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<StreamConfigRetention>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<StreamConfigStorage>(JsonNamingPolicy.SnakeCaseLower),
+        },
+    }));
+#endif
 }
 
 [JsonSerializable(typeof(AccountInfoResponse))]
@@ -88,6 +104,7 @@ internal partial class NatsJSJsonSerializerContext : JsonSerializerContext
 {
 }
 
+#if NET6_0
 internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
     where TEnum : struct, Enum
 {
@@ -174,7 +191,7 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
             case "interest":
                 return (TEnum)(object)StreamConfigRetention.Interest;
             case "workqueue":
-                return (TEnum)(object)StreamConfigRetention.WorkQueue;
+                return (TEnum)(object)StreamConfigRetention.Workqueue;
             }
         }
 
@@ -279,7 +296,7 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
             case StreamConfigRetention.Interest:
                 writer.WriteStringValue("interest");
                 return;
-            case StreamConfigRetention.WorkQueue:
+            case StreamConfigRetention.Workqueue:
                 writer.WriteStringValue("workqueue");
                 return;
             }
@@ -300,3 +317,4 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
         throw new InvalidOperationException($"Writing unknown enum value {value.GetType().Name}.{value}");
     }
 }
+#endif

--- a/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using NATS.Client.Core;
 using NATS.Client.JetStream.Models;
@@ -85,4 +86,217 @@ internal static class NatsJSJsonSerializer<T>
 [JsonSerializable(typeof(Tier))]
 internal partial class NatsJSJsonSerializerContext : JsonSerializerContext
 {
+}
+
+internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
+    where TEnum : struct, Enum
+{
+    public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new InvalidOperationException();
+        }
+
+        var stringValue = reader.GetString();
+
+        if (typeToConvert == typeof(ConsumerConfigDeliverPolicy))
+        {
+            switch (stringValue)
+            {
+            case "all":
+                return (TEnum)(object)ConsumerConfigDeliverPolicy.All;
+            case "last":
+                return (TEnum)(object)ConsumerConfigDeliverPolicy.Last;
+            case "new":
+                return (TEnum)(object)ConsumerConfigDeliverPolicy.New;
+            case "by_start_sequence":
+                return (TEnum)(object)ConsumerConfigDeliverPolicy.ByStartSequence;
+            case "by_start_time":
+                return (TEnum)(object)ConsumerConfigDeliverPolicy.ByStartTime;
+            case "last_per_subject":
+                return (TEnum)(object)ConsumerConfigDeliverPolicy.LastPerSubject;
+            }
+        }
+
+        if (typeToConvert == typeof(ConsumerConfigAckPolicy))
+        {
+            switch (stringValue)
+            {
+            case "none":
+                return (TEnum)(object)ConsumerConfigAckPolicy.None;
+            case "all":
+                return (TEnum)(object)ConsumerConfigAckPolicy.All;
+            case "explicit":
+                return (TEnum)(object)ConsumerConfigAckPolicy.Explicit;
+            }
+        }
+
+        if (typeToConvert == typeof(ConsumerConfigReplayPolicy))
+        {
+            switch (stringValue)
+            {
+            case "instant":
+                return (TEnum)(object)ConsumerConfigReplayPolicy.Instant;
+            case "original":
+                return (TEnum)(object)ConsumerConfigReplayPolicy.Original;
+            }
+        }
+
+        if (typeToConvert == typeof(StreamConfigCompression))
+        {
+            switch (stringValue)
+            {
+            case "none":
+                return (TEnum)(object)StreamConfigCompression.None;
+            case "s2":
+                return (TEnum)(object)StreamConfigCompression.S2;
+            }
+        }
+
+        if (typeToConvert == typeof(StreamConfigDiscard))
+        {
+            switch (stringValue)
+            {
+            case "old":
+                return (TEnum)(object)StreamConfigDiscard.Old;
+            case "new":
+                return (TEnum)(object)StreamConfigDiscard.New;
+            }
+        }
+
+        if (typeToConvert == typeof(StreamConfigRetention))
+        {
+            switch (stringValue)
+            {
+            case "limits":
+                return (TEnum)(object)StreamConfigRetention.Limits;
+            case "interest":
+                return (TEnum)(object)StreamConfigRetention.Interest;
+            case "workqueue":
+                return (TEnum)(object)StreamConfigRetention.WorkQueue;
+            }
+        }
+
+        if (typeToConvert == typeof(StreamConfigStorage))
+        {
+            switch (stringValue)
+            {
+            case "file":
+                return (TEnum)(object)StreamConfigStorage.File;
+            case "memory":
+                return (TEnum)(object)StreamConfigStorage.Memory;
+            }
+        }
+
+        throw new InvalidOperationException($"Reading unknown enum type {typeToConvert.Name} or value {stringValue}");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+    {
+        if (value is ConsumerConfigDeliverPolicy consumerConfigDeliverPolicy)
+        {
+            switch (consumerConfigDeliverPolicy)
+            {
+            case ConsumerConfigDeliverPolicy.All:
+                writer.WriteStringValue("all");
+                return;
+            case ConsumerConfigDeliverPolicy.Last:
+                writer.WriteStringValue("last");
+                return;
+            case ConsumerConfigDeliverPolicy.New:
+                writer.WriteStringValue("new");
+                return;
+            case ConsumerConfigDeliverPolicy.ByStartSequence:
+                writer.WriteStringValue("by_start_sequence");
+                return;
+            case ConsumerConfigDeliverPolicy.ByStartTime:
+                writer.WriteStringValue("by_start_time");
+                return;
+            case ConsumerConfigDeliverPolicy.LastPerSubject:
+                writer.WriteStringValue("last_per_subject");
+                return;
+            }
+        }
+        else if (value is ConsumerConfigAckPolicy consumerConfigAckPolicy)
+        {
+            switch (consumerConfigAckPolicy)
+            {
+            case ConsumerConfigAckPolicy.None:
+                writer.WriteStringValue("none");
+                return;
+            case ConsumerConfigAckPolicy.All:
+                writer.WriteStringValue("all");
+                return;
+            case ConsumerConfigAckPolicy.Explicit:
+                writer.WriteStringValue("explicit");
+                return;
+            }
+        }
+        else if (value is ConsumerConfigReplayPolicy consumerConfigReplayPolicy)
+        {
+            switch (consumerConfigReplayPolicy)
+            {
+            case ConsumerConfigReplayPolicy.Instant:
+                writer.WriteStringValue("instant");
+                return;
+            case ConsumerConfigReplayPolicy.Original:
+                writer.WriteStringValue("original");
+                return;
+            }
+        }
+        else if (value is StreamConfigCompression streamConfigCompression)
+        {
+            switch (streamConfigCompression)
+            {
+            case StreamConfigCompression.None:
+                writer.WriteStringValue("none");
+                return;
+            case StreamConfigCompression.S2:
+                writer.WriteStringValue("s2");
+                return;
+            }
+        }
+        else if (value is StreamConfigDiscard streamConfigDiscard)
+        {
+            switch (streamConfigDiscard)
+            {
+            case StreamConfigDiscard.Old:
+                writer.WriteStringValue("old");
+                return;
+            case StreamConfigDiscard.New:
+                writer.WriteStringValue("new");
+                return;
+            }
+        }
+        else if (value is StreamConfigRetention streamConfigRetention)
+        {
+            switch (streamConfigRetention)
+            {
+            case StreamConfigRetention.Limits:
+                writer.WriteStringValue("limits");
+                return;
+            case StreamConfigRetention.Interest:
+                writer.WriteStringValue("interest");
+                return;
+            case StreamConfigRetention.WorkQueue:
+                writer.WriteStringValue("workqueue");
+                return;
+            }
+        }
+        else if (value is StreamConfigStorage streamConfigStorage)
+        {
+            switch (streamConfigStorage)
+            {
+            case StreamConfigStorage.File:
+                writer.WriteStringValue("file");
+                return;
+            case StreamConfigStorage.Memory:
+                writer.WriteStringValue("memory");
+                return;
+            }
+        }
+
+        throw new InvalidOperationException($"Writing unknown enum value {value.GetType().Name}.{value}");
+    }
 }

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
@@ -36,7 +36,7 @@ internal record NatsJSOrderedPushConsumerOpts
     /// </summary>
     public TimeSpan IdleHeartbeat { get; init; } = TimeSpan.FromSeconds(5);
 
-    public ConsumerConfigDeliverPolicy DeliverPolicy { get; init; } = ConsumerConfigDeliverPolicy.all;
+    public ConsumerConfigDeliverPolicy DeliverPolicy { get; init; } = ConsumerConfigDeliverPolicy.All;
 
     public bool HeadersOnly { get; init; } = false;
 }
@@ -338,8 +338,8 @@ internal class NatsJSOrderedPushConsumer<T>
         var config = new ConsumerConfig
         {
             Name = Consumer,
-            DeliverPolicy = ConsumerConfigDeliverPolicy.all,
-            AckPolicy = ConsumerConfigAckPolicy.none,
+            DeliverPolicy = ConsumerConfigDeliverPolicy.All,
+            AckPolicy = ConsumerConfigAckPolicy.None,
             DeliverSubject = _sub.Subject,
             FilterSubject = _filter,
             FlowControl = true,
@@ -348,7 +348,7 @@ internal class NatsJSOrderedPushConsumer<T>
             MaxDeliver = 1,
             MemStorage = true,
             NumReplicas = 1,
-            ReplayPolicy = ConsumerConfigReplayPolicy.instant,
+            ReplayPolicy = ConsumerConfigReplayPolicy.Instant,
         };
 
         config.DeliverPolicy = _opts.DeliverPolicy;
@@ -356,7 +356,7 @@ internal class NatsJSOrderedPushConsumer<T>
 
         if (sequence > 0)
         {
-            config.DeliverPolicy = ConsumerConfigDeliverPolicy.by_start_sequence;
+            config.DeliverPolicy = ConsumerConfigDeliverPolicy.ByStartSequence;
             config.OptStartSeq = sequence + 1;
         }
 

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -18,7 +18,9 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("deliver_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigDeliverPolicy>))]
+#endif
     public ConsumerConfigDeliverPolicy DeliverPolicy { get; set; } = default!;
 
     [System.Text.Json.Serialization.JsonPropertyName("opt_start_seq")]
@@ -64,7 +66,9 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("ack_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigAckPolicy>))]
+#endif
     public ConsumerConfigAckPolicy AckPolicy { get; set; } = ConsumerConfigAckPolicy.None;
 
     /// <summary>
@@ -100,7 +104,9 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("replay_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigReplayPolicy>))]
+#endif
     public ConsumerConfigReplayPolicy ReplayPolicy { get; set; } = NATS.Client.JetStream.Models.ConsumerConfigReplayPolicy.Instant;
 
     [System.Text.Json.Serialization.JsonPropertyName("sample_freq")]

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -1,3 +1,5 @@
+using NATS.Client.JetStream.Internal;
+
 namespace NATS.Client.JetStream.Models;
 
 public record ConsumerConfig
@@ -10,17 +12,13 @@ public record ConsumerConfig
     {
         Name = name;
         DurableName = name;
-        AckPolicy = ConsumerConfigAckPolicy.@explicit;
+        AckPolicy = ConsumerConfigAckPolicy.Explicit;
     }
 
     [System.Text.Json.Serialization.JsonPropertyName("deliver_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-#if NET6_0
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-#else
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<ConsumerConfigDeliverPolicy>))]
-#endif
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigDeliverPolicy>))]
     public ConsumerConfigDeliverPolicy DeliverPolicy { get; set; } = default!;
 
     [System.Text.Json.Serialization.JsonPropertyName("opt_start_seq")]
@@ -66,12 +64,8 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("ack_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-#if NET6_0
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-#else
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<ConsumerConfigAckPolicy>))]
-#endif
-    public ConsumerConfigAckPolicy AckPolicy { get; set; } = ConsumerConfigAckPolicy.none;
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigAckPolicy>))]
+    public ConsumerConfigAckPolicy AckPolicy { get; set; } = ConsumerConfigAckPolicy.None;
 
     /// <summary>
     /// How long (in nanoseconds) to allow messages to remain un-acknowledged before attempting redelivery
@@ -106,12 +100,8 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("replay_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-#if NET6_0
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-#else
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<ConsumerConfigReplayPolicy>))]
-#endif
-    public ConsumerConfigReplayPolicy ReplayPolicy { get; set; } = NATS.Client.JetStream.Models.ConsumerConfigReplayPolicy.instant;
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigReplayPolicy>))]
+    public ConsumerConfigReplayPolicy ReplayPolicy { get; set; } = NATS.Client.JetStream.Models.ConsumerConfigReplayPolicy.Instant;
 
     [System.Text.Json.Serialization.JsonPropertyName("sample_freq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
@@ -1,15 +1,8 @@
 namespace NATS.Client.JetStream.Models;
 
-// TODO: enum member naming with JSON serialization isn't working for some reason
-#pragma warning disable SA1300
 public enum ConsumerConfigAckPolicy
 {
-    [System.Runtime.Serialization.EnumMember(Value = @"none")]
-    none = 0,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"all")]
-    all = 1,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"explicit")]
-    @explicit = 2,
+    None = 0,
+    All = 1,
+    Explicit = 2,
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigDeliverPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigDeliverPolicy.cs
@@ -1,24 +1,11 @@
 namespace NATS.Client.JetStream.Models;
 
-// TODO: enum member naming with JSON serialization isn't working for some reason
-#pragma warning disable SA1300
 public enum ConsumerConfigDeliverPolicy
 {
-    [System.Runtime.Serialization.EnumMember(Value = @"all")]
-    all = 0,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"last")]
-    last = 1,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"new")]
-    @new = 2,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"by_start_sequence")]
-    by_start_sequence = 3,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"by_start_time")]
-    by_start_time = 4,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"last_per_subject")]
-    last_per_subject = 5,
+    All = 0,
+    Last = 1,
+    New = 2,
+    ByStartSequence = 3,
+    ByStartTime = 4,
+    LastPerSubject = 5,
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigReplayPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigReplayPolicy.cs
@@ -1,12 +1,7 @@
 namespace NATS.Client.JetStream.Models;
 
-// TODO: enum member naming with JSON serialization isn't working for some reason
-#pragma warning disable SA1300
 public enum ConsumerConfigReplayPolicy
 {
-    [System.Runtime.Serialization.EnumMember(Value = @"instant")]
-    instant = 0,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"original")]
-    original = 1,
+    Instant = 0,
+    Original = 1,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -1,3 +1,5 @@
+using NATS.Client.JetStream.Internal;
+
 namespace NATS.Client.JetStream.Models;
 
 public record StreamConfig
@@ -49,12 +51,8 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("retention")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-#if NET6_0
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-#else
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<StreamConfigRetention>))]
-#endif
-    public StreamConfigRetention Retention { get; set; } = NATS.Client.JetStream.Models.StreamConfigRetention.limits;
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigRetention>))]
+    public StreamConfigRetention Retention { get; set; } = NATS.Client.JetStream.Models.StreamConfigRetention.Limits;
 
     /// <summary>
     /// How many Consumers can be defined for a given Stream. -1 for unlimited.
@@ -110,24 +108,16 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-#if NET6_0
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-#else
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<StreamConfigStorage>))]
-#endif
-    public StreamConfigStorage Storage { get; set; } = StreamConfigStorage.file;
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigStorage>))]
+    public StreamConfigStorage Storage { get; set; } = StreamConfigStorage.File;
 
     /// <summary>
     /// Optional compression algorithm used for the Stream.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("compression")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-#if NET6_0
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-#else
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<StreamConfigCompression>))]
-#endif
-    public StreamConfigCompression Compression { get; set; } = NATS.Client.JetStream.Models.StreamConfigCompression.none;
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigCompression>))]
+    public StreamConfigCompression Compression { get; set; } = NATS.Client.JetStream.Models.StreamConfigCompression.None;
 
     /// <summary>
     /// How many replicas to keep for each message.
@@ -156,12 +146,8 @@ public record StreamConfig
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("discard")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-#if NET6_0
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
-#else
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<StreamConfigDiscard>))]
-#endif
-    public StreamConfigDiscard Discard { get; set; } = StreamConfigDiscard.old;
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigDiscard>))]
+    public StreamConfigDiscard Discard { get; set; } = StreamConfigDiscard.Old;
 
     /// <summary>
     /// The time window to track duplicate messages for, expressed in nanoseconds. 0 for default

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -51,7 +51,9 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("retention")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigRetention>))]
+#endif
     public StreamConfigRetention Retention { get; set; } = NATS.Client.JetStream.Models.StreamConfigRetention.Limits;
 
     /// <summary>
@@ -108,7 +110,9 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigStorage>))]
+#endif
     public StreamConfigStorage Storage { get; set; } = StreamConfigStorage.File;
 
     /// <summary>
@@ -116,7 +120,9 @@ public record StreamConfig
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("compression")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+#if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigCompression>))]
+#endif
     public StreamConfigCompression Compression { get; set; } = NATS.Client.JetStream.Models.StreamConfigCompression.None;
 
     /// <summary>
@@ -146,7 +152,9 @@ public record StreamConfig
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("discard")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+#if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigDiscard>))]
+#endif
     public StreamConfigDiscard Discard { get; set; } = StreamConfigDiscard.Old;
 
     /// <summary>

--- a/src/NATS.Client.JetStream/Models/StreamConfigCompression.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigCompression.cs
@@ -1,12 +1,7 @@
 namespace NATS.Client.JetStream.Models;
 
-// TODO: enum member naming with JSON serialization isn't working for some reason
-#pragma warning disable SA1300
 public enum StreamConfigCompression
 {
-    [System.Runtime.Serialization.EnumMember(Value = @"none")]
-    none = 0,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"s2")]
-    s2 = 1,
+    None = 0,
+    S2 = 1,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigDiscard.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigDiscard.cs
@@ -1,12 +1,7 @@
 namespace NATS.Client.JetStream.Models;
 
-// TODO: enum member naming with JSON serialization isn't working for some reason
-#pragma warning disable SA1300
 public enum StreamConfigDiscard
 {
-    [System.Runtime.Serialization.EnumMember(Value = @"old")]
-    old = 0,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"new")]
-    @new = 1,
+    Old = 0,
+    New = 1,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigRetention.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigRetention.cs
@@ -4,5 +4,5 @@ public enum StreamConfigRetention
 {
     Limits = 0,
     Interest = 1,
-    WorkQueue = 2,
+    Workqueue = 2,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigRetention.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigRetention.cs
@@ -1,15 +1,8 @@
 namespace NATS.Client.JetStream.Models;
 
-// TODO: enum member naming with JSON serialization isn't working for some reason
-#pragma warning disable SA1300
 public enum StreamConfigRetention
 {
-    [System.Runtime.Serialization.EnumMember(Value = @"limits")]
-    limits = 0,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"interest")]
-    interest = 1,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"workqueue")]
-    workqueue = 2,
+    Limits = 0,
+    Interest = 1,
+    WorkQueue = 2,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigStorage.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigStorage.cs
@@ -1,12 +1,7 @@
 namespace NATS.Client.JetStream.Models;
 
-// TODO: enum member naming with JSON serialization isn't working for some reason
-#pragma warning disable SA1300
 public enum StreamConfigStorage
 {
-    [System.Runtime.Serialization.EnumMember(Value = @"file")]
-    file = 0,
-
-    [System.Runtime.Serialization.EnumMember(Value = @"memory")]
-    memory = 1,
+    File = 0,
+    Memory = 1,
 }

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -150,7 +150,7 @@ public partial class NatsJSContext : INatsJSContext
             Config = new ConsumerConfig
             {
                 DeliverPolicy = opts.DeliverPolicy,
-                AckPolicy = ConsumerConfigAckPolicy.none,
+                AckPolicy = ConsumerConfigAckPolicy.None,
                 ReplayPolicy = opts.ReplayPolicy,
                 InactiveThreshold = opts.InactiveThreshold.ToNanos(),
                 NumReplicas = 1,

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -66,13 +66,13 @@ public record NatsJSOrderedConsumerOpts
 
     public string[] FilterSubjects { get; init; } = Array.Empty<string>();
 
-    public ConsumerConfigDeliverPolicy DeliverPolicy { get; init; } = ConsumerConfigDeliverPolicy.all;
+    public ConsumerConfigDeliverPolicy DeliverPolicy { get; init; } = ConsumerConfigDeliverPolicy.All;
 
     public ulong OptStartSeq { get; init; } = 0;
 
     public DateTimeOffset OptStartTime { get; init; } = default;
 
-    public ConsumerConfigReplayPolicy ReplayPolicy { get; init; } = ConsumerConfigReplayPolicy.instant;
+    public ConsumerConfigReplayPolicy ReplayPolicy { get; init; } = ConsumerConfigReplayPolicy.Instant;
 
     public TimeSpan InactiveThreshold { get; init; } = TimeSpan.FromMinutes(5);
 

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -262,7 +262,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
             consumerOpts = _opts with
             {
                 OptStartSeq = seq + 1,
-                DeliverPolicy = ConsumerConfigDeliverPolicy.by_start_sequence,
+                DeliverPolicy = ConsumerConfigDeliverPolicy.ByStartSequence,
             };
 
             if (consumer != string.Empty)

--- a/src/NATS.Client.KeyValueStore/Internal/NatsKVWatcher.cs
+++ b/src/NATS.Client.KeyValueStore/Internal/NatsKVWatcher.cs
@@ -342,8 +342,8 @@ internal class NatsKVWatcher<T> : IAsyncDisposable
         var config = new ConsumerConfig
         {
             Name = Consumer,
-            DeliverPolicy = ConsumerConfigDeliverPolicy.all,
-            AckPolicy = ConsumerConfigAckPolicy.none,
+            DeliverPolicy = ConsumerConfigDeliverPolicy.All,
+            AckPolicy = ConsumerConfigAckPolicy.None,
             DeliverSubject = _sub.Subject,
             FilterSubject = _filter,
             FlowControl = true,
@@ -352,17 +352,17 @@ internal class NatsKVWatcher<T> : IAsyncDisposable
             MaxDeliver = 1,
             MemStorage = true,
             NumReplicas = 1,
-            ReplayPolicy = ConsumerConfigReplayPolicy.instant,
+            ReplayPolicy = ConsumerConfigReplayPolicy.Instant,
         };
 
         if (!_opts.IncludeHistory)
         {
-            config.DeliverPolicy = ConsumerConfigDeliverPolicy.last_per_subject;
+            config.DeliverPolicy = ConsumerConfigDeliverPolicy.LastPerSubject;
         }
 
         if (_opts.UpdatesOnly)
         {
-            config.DeliverPolicy = ConsumerConfigDeliverPolicy.@new;
+            config.DeliverPolicy = ConsumerConfigDeliverPolicy.New;
         }
 
         if (_opts.MetaOnly)
@@ -372,7 +372,7 @@ internal class NatsKVWatcher<T> : IAsyncDisposable
 
         if (sequence > 0)
         {
-            config.DeliverPolicy = ConsumerConfigDeliverPolicy.by_start_sequence;
+            config.DeliverPolicy = ConsumerConfigDeliverPolicy.ByStartSequence;
             config.OptStartSeq = sequence + 1;
         }
 

--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -71,8 +71,8 @@ public class NatsKVContext : INatsKVContext
         }
 
         var storage = config.Storage == NatsKVStorageType.File
-            ? StreamConfigStorage.file
-            : StreamConfigStorage.memory;
+            ? StreamConfigStorage.File
+            : StreamConfigStorage.Memory;
 
         var republish = config.Republish != null
             ? new Republish
@@ -94,7 +94,7 @@ public class NatsKVContext : INatsKVContext
             MaxBytes = config.MaxBytes,
             MaxAge = config.MaxAge.ToNanos(),
             MaxMsgSize = config.MaxValueSize,
-            Compression = config.Compression ? StreamConfigCompression.s2 : StreamConfigCompression.none,
+            Compression = config.Compression ? StreamConfigCompression.S2 : StreamConfigCompression.None,
             Storage = storage,
             Republish = republish!,
             AllowRollupHdrs = true,
@@ -102,12 +102,12 @@ public class NatsKVContext : INatsKVContext
             DenyPurge = false,
             AllowDirect = true,
             NumReplicas = replicas,
-            Discard = StreamConfigDiscard.@new,
+            Discard = StreamConfigDiscard.New,
 
             // TODO: KV mirrors
             // MirrorDirect =
             // Mirror =
-            Retention = StreamConfigRetention.limits, // from ADR-8
+            Retention = StreamConfigRetention.Limits, // from ADR-8
             DuplicateWindow = 120000000000, // from ADR-8
         };
 

--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -350,7 +350,7 @@ public class NatsKVStore : INatsKVStore
     public async ValueTask<NatsKVStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
         await _stream.RefreshAsync(cancellationToken);
-        var isCompressed = _stream.Info.Config.Compression != StreamConfigCompression.none;
+        var isCompressed = _stream.Info.Config.Compression != StreamConfigCompression.None;
         return new NatsKVStatus(Bucket, isCompressed, _stream.Info);
     }
 

--- a/src/NATS.Client.ObjectStore/NatsObjContext.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjContext.cs
@@ -40,8 +40,8 @@ public class NatsObjContext : INatsObjContext
         ValidateBucketName(config.Bucket);
 
         var storage = config.Storage == NatsObjStorageType.File
-            ? StreamConfigStorage.file
-            : StreamConfigStorage.memory;
+            ? StreamConfigStorage.File
+            : StreamConfigStorage.Memory;
 
         var streamConfig = new StreamConfig
         {
@@ -53,12 +53,12 @@ public class NatsObjContext : INatsObjContext
             Storage = storage,
             NumReplicas = config.NumberOfReplicas,
             /* TODO: Placement = */
-            Discard = StreamConfigDiscard.@new,
+            Discard = StreamConfigDiscard.New,
             AllowRollupHdrs = true,
             AllowDirect = true,
             Metadata = config.Metadata!,
-            Retention = StreamConfigRetention.limits,
-            Compression = config.Compression ? StreamConfigCompression.s2 : StreamConfigCompression.none,
+            Retention = StreamConfigRetention.Limits,
+            Compression = config.Compression ? StreamConfigCompression.S2 : StreamConfigCompression.None,
         };
 
         var stream = await _context.CreateStreamAsync(streamConfig, cancellationToken);

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -82,7 +82,7 @@ public class NatsObjStore : INatsObjStore
             stream: $"OBJ_{Bucket}",
             filter: GetChunkSubject(info.Nuid),
             serializer: NatsDefaultSerializer<NatsMemoryOwner<byte>>.Default,
-            opts: new NatsJSOrderedPushConsumerOpts { DeliverPolicy = ConsumerConfigDeliverPolicy.all },
+            opts: new NatsJSOrderedPushConsumerOpts { DeliverPolicy = ConsumerConfigDeliverPolicy.All },
             subOpts: new NatsSubOpts(),
             cancellationToken: cancellationToken);
 
@@ -533,7 +533,7 @@ public class NatsObjStore : INatsObjStore
     public async ValueTask<NatsObjStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
         await _stream.RefreshAsync(cancellationToken);
-        var isCompressed = _stream.Info.Config.Compression != StreamConfigCompression.none;
+        var isCompressed = _stream.Info.Config.Compression != StreamConfigCompression.None;
         return new NatsObjStatus(Bucket, isCompressed, _stream.Info);
     }
 
@@ -547,16 +547,16 @@ public class NatsObjStore : INatsObjStore
     {
         opts ??= new NatsObjWatchOpts();
 
-        var deliverPolicy = ConsumerConfigDeliverPolicy.all;
+        var deliverPolicy = ConsumerConfigDeliverPolicy.All;
 
         if (!opts.IncludeHistory)
         {
-            deliverPolicy = ConsumerConfigDeliverPolicy.last_per_subject;
+            deliverPolicy = ConsumerConfigDeliverPolicy.LastPerSubject;
         }
 
         if (opts.UpdatesOnly)
         {
-            deliverPolicy = ConsumerConfigDeliverPolicy.@new;
+            deliverPolicy = ConsumerConfigDeliverPolicy.New;
         }
 
         await using var pushConsumer = new NatsJSOrderedPushConsumer<NatsMemoryOwner<byte>>(

--- a/tests/NATS.Client.CheckNativeAot/Program.cs
+++ b/tests/NATS.Client.CheckNativeAot/Program.cs
@@ -85,7 +85,7 @@ async Task JetStreamTests()
                 DurableName = "consumer1",
 
                 // Turn on ACK so we can test them below
-                AckPolicy = ConsumerConfigAckPolicy.@explicit,
+                AckPolicy = ConsumerConfigAckPolicy.Explicit,
             },
             cts1.Token);
         AssertEqual("events", consumer.Info.StreamName);

--- a/tests/NATS.Client.Core.MemoryTests/NatsConsumeTests.cs
+++ b/tests/NATS.Client.Core.MemoryTests/NatsConsumeTests.cs
@@ -23,7 +23,7 @@ public class NatsConsumeTests
             {
                 await js.CreateStreamAsync(new StreamConfig { Name = "s1", Subjects = new[] { "s1.*" } });
 
-                var consumer = await js.CreateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1", AckPolicy = ConsumerConfigAckPolicy.@explicit });
+                var consumer = await js.CreateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1", AckPolicy = ConsumerConfigAckPolicy.Explicit });
 
                 var count = 0;
                 await foreach (var msg in consumer.ConsumeAsync<int>(opts: new NatsJSConsumeOpts { MaxMsgs = 100 }))

--- a/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
@@ -1,0 +1,151 @@
+﻿using System.Buffers;
+using System.Text;
+using NATS.Client.JetStream.Internal;
+using NATS.Client.JetStream.Models;
+
+namespace NATS.Client.JetStream.Tests;
+
+public class EnumJsonTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public EnumJsonTests(ITestOutputHelper output) => _output = output;
+
+    [Theory]
+    [InlineData(ConsumerConfigAckPolicy.All, "\"ack_policy\":\"all\"")]
+    [InlineData(ConsumerConfigAckPolicy.Explicit, "\"ack_policy\":\"explicit\"")]
+    [InlineData(ConsumerConfigAckPolicy.None, "\"ack_policy\":\"none\"")]
+    public void ConsumerConfigAckPolicy_test(ConsumerConfigAckPolicy value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<ConsumerConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new ConsumerConfig { AckPolicy = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.AckPolicy);
+    }
+
+    [Theory]
+    [InlineData(ConsumerConfigDeliverPolicy.All, "\"deliver_policy\":\"all\"")]
+    [InlineData(ConsumerConfigDeliverPolicy.Last, "\"deliver_policy\":\"last\"")]
+    [InlineData(ConsumerConfigDeliverPolicy.New, "\"deliver_policy\":\"new\"")]
+    [InlineData(ConsumerConfigDeliverPolicy.ByStartSequence, "\"deliver_policy\":\"by_start_sequence\"")]
+    [InlineData(ConsumerConfigDeliverPolicy.ByStartTime, "\"deliver_policy\":\"by_start_time\"")]
+    [InlineData(ConsumerConfigDeliverPolicy.LastPerSubject, "\"deliver_policy\":\"last_per_subject\"")]
+    public void ConsumerConfigDeliverPolicy_test(ConsumerConfigDeliverPolicy value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<ConsumerConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new ConsumerConfig { DeliverPolicy = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.DeliverPolicy);
+    }
+
+    [Theory]
+    [InlineData(ConsumerConfigReplayPolicy.Instant, "\"replay_policy\":\"instant\"")]
+    [InlineData(ConsumerConfigReplayPolicy.Original, "\"replay_policy\":\"original\"")]
+    public void ConsumerConfigReplayPolicy_test(ConsumerConfigReplayPolicy value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<ConsumerConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new ConsumerConfig { ReplayPolicy = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.ReplayPolicy);
+    }
+
+    [Theory]
+    [InlineData(StreamConfigCompression.None, "\"compression\":\"none\"")]
+    [InlineData(StreamConfigCompression.S2, "\"compression\":\"s2\"")]
+    public void StreamConfigCompression_test(StreamConfigCompression value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<StreamConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new StreamConfig { Compression = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        if (value == default)
+            Assert.DoesNotContain(expected, json);
+        else
+            Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.Compression);
+    }
+
+    [Theory]
+    [InlineData(StreamConfigDiscard.Old, "\"discard\":\"old\"")]
+    [InlineData(StreamConfigDiscard.New, "\"discard\":\"new\"")]
+    public void StreamConfigDiscard_test(StreamConfigDiscard value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<StreamConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new StreamConfig { Discard = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        if (value == default)
+            Assert.DoesNotContain(expected, json);
+        else
+            Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.Discard);
+    }
+
+    [Theory]
+    [InlineData(StreamConfigRetention.Limits, "\"retention\":\"limits\"")]
+    [InlineData(StreamConfigRetention.Interest, "\"retention\":\"interest\"")]
+    [InlineData(StreamConfigRetention.WorkQueue, "\"retention\":\"workqueue\"")]
+    public void StreamConfigRetention_test(StreamConfigRetention value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<StreamConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new StreamConfig { Retention = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.Retention);
+    }
+
+    [Theory]
+    [InlineData(StreamConfigStorage.File, "\"storage\":\"file\"")]
+    [InlineData(StreamConfigStorage.Memory, "\"storage\":\"memory\"")]
+    public void StreamConfigStorage_test(StreamConfigStorage value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<StreamConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new StreamConfig { Storage = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.Storage);
+    }
+}

--- a/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
@@ -115,7 +115,7 @@ public class EnumJsonTests
     [Theory]
     [InlineData(StreamConfigRetention.Limits, "\"retention\":\"limits\"")]
     [InlineData(StreamConfigRetention.Interest, "\"retention\":\"interest\"")]
-    [InlineData(StreamConfigRetention.WorkQueue, "\"retention\":\"workqueue\"")]
+    [InlineData(StreamConfigRetention.Workqueue, "\"retention\":\"workqueue\"")]
     public void StreamConfigRetention_test(StreamConfigRetention value, string expected)
     {
         var serializer = NatsJSJsonSerializer<StreamConfig>.Default;

--- a/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
@@ -42,7 +42,7 @@ public class JetStreamTest
                     DurableName = "consumer1",
 
                     // Turn on ACK so we can test them below
-                    AckPolicy = ConsumerConfigAckPolicy.@explicit,
+                    AckPolicy = ConsumerConfigAckPolicy.Explicit,
                 },
                 cts1.Token);
             Assert.Equal("events", consumer.Info.StreamName);

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
@@ -47,12 +47,12 @@ public class KeyValueStoreTest
             Name = $"KV_{bucket}",
             Subjects = new[] { $"$KV.{bucket}.>" },
             AllowDirect = false, // this property makes the switch
-            Discard = StreamConfigDiscard.@new,
+            Discard = StreamConfigDiscard.New,
             DenyDelete = true,
             DenyPurge = false,
             NumReplicas = 1,
             MaxMsgsPerSubject = 10,
-            Retention = StreamConfigRetention.limits,
+            Retention = StreamConfigRetention.Limits,
             DuplicateWindow = 120000000000,
         });
 
@@ -544,11 +544,11 @@ public class KeyValueStoreTest
         var status1 = await store1.GetStatusAsync(cancellationToken);
         Assert.Equal("kv1", status1.Bucket);
         Assert.Equal("KV_kv1", status1.Info.Config.Name);
-        Assert.Equal(StreamConfigCompression.none, status1.Info.Config.Compression);
+        Assert.Equal(StreamConfigCompression.None, status1.Info.Config.Compression);
 
         var status2 = await store2.GetStatusAsync(cancellationToken);
         Assert.Equal("kv2", status2.Bucket);
         Assert.Equal("KV_kv2", status2.Info.Config.Name);
-        Assert.Equal(StreamConfigCompression.s2, status2.Info.Config.Compression);
+        Assert.Equal(StreamConfigCompression.S2, status2.Info.Config.Compression);
     }
 }

--- a/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
@@ -388,11 +388,11 @@ public class ObjectStoreTest
         var status1 = await store1.GetStatusAsync(cancellationToken);
         Assert.Equal("b1", status1.Bucket);
         Assert.Equal("OBJ_b1", status1.Info.Config.Name);
-        Assert.Equal(StreamConfigCompression.none, status1.Info.Config.Compression);
+        Assert.Equal(StreamConfigCompression.None, status1.Info.Config.Compression);
 
         var status2 = await store2.GetStatusAsync(cancellationToken);
         Assert.Equal("b2", status2.Bucket);
         Assert.Equal("OBJ_b2", status2.Info.Config.Name);
-        Assert.Equal(StreamConfigCompression.s2, status2.Info.Config.Compression);
+        Assert.Equal(StreamConfigCompression.S2, status2.Info.Config.Compression);
     }
 }


### PR DESCRIPTION
System.Text.Json serializer has some difficult settings serializing enums. Before we just relied on unconventional property names in code but proper way is to use PascalCase. Unfortunately the JSON options also did not allow snake_case conversion also I didn't want to force System.Text.Json v8 onto net6.0 targets (if that supports it). Hence we now have a JetStream specific JSON enum convertor.