### PR TITLE
Removed redundant StreamUpdateRequest class

### DIFF
--- a/src/NATS.Client.JetStream/INatsJSContext.cs
+++ b/src/NATS.Client.JetStream/INatsJSContext.cs
@@ -190,7 +190,7 @@ public interface INatsJSContext
     /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
     /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
     ValueTask<NatsJSStream> UpdateStreamAsync(
-        StreamUpdateRequest request,
+        StreamConfig request,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/NATS.Client.JetStream/INatsJSStream.cs
+++ b/src/NATS.Client.JetStream/INatsJSStream.cs
@@ -49,7 +49,7 @@ public interface INatsJSStream
     /// <exception cref="NatsJSException">There is an error retrieving the response or this consumer object isn't valid anymore because it was deleted earlier.</exception>
     /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
     ValueTask UpdateAsync(
-        StreamUpdateRequest request,
+        StreamConfig request,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
@@ -96,7 +96,6 @@ internal static class NatsJSJsonSerializer<T>
 [JsonSerializable(typeof(StreamTemplateInfoResponse))]
 [JsonSerializable(typeof(StreamTemplateNamesRequest))]
 [JsonSerializable(typeof(StreamTemplateNamesResponse))]
-[JsonSerializable(typeof(StreamUpdateRequest))]
 [JsonSerializable(typeof(StreamUpdateResponse))]
 [JsonSerializable(typeof(SubjectTransform))]
 [JsonSerializable(typeof(Tier))]

--- a/src/NATS.Client.JetStream/Models/StreamUpdateRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamUpdateRequest.cs
@@ -1,9 +1,0 @@
-namespace NATS.Client.JetStream.Models;
-
-/// <summary>
-/// A request to the JetStream $JS.API.STREAM.UPDATE API
-/// </summary>
-
-public record StreamUpdateRequest : StreamConfig
-{
-}

--- a/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
@@ -115,10 +115,10 @@ public partial class NatsJSContext
     /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
     /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
     public async ValueTask<NatsJSStream> UpdateStreamAsync(
-        StreamUpdateRequest request,
+        StreamConfig request,
         CancellationToken cancellationToken = default)
     {
-        var response = await JSRequestResponseAsync<StreamUpdateRequest, StreamUpdateResponse>(
+        var response = await JSRequestResponseAsync<StreamConfig, StreamUpdateResponse>(
             subject: $"{Opts.Prefix}.STREAM.UPDATE.{request.Name}",
             request: request,
             cancellationToken);

--- a/src/NATS.Client.JetStream/NatsJSStream.cs
+++ b/src/NATS.Client.JetStream/NatsJSStream.cs
@@ -76,7 +76,7 @@ public class NatsJSStream : INatsJSStream
     /// <exception cref="NatsJSException">There is an error retrieving the response or this consumer object isn't valid anymore because it was deleted earlier.</exception>
     /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
     public async ValueTask UpdateAsync(
-        StreamUpdateRequest request,
+        StreamConfig request,
         CancellationToken cancellationToken = default)
     {
         ThrowIfDeleted();

--- a/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
@@ -48,7 +48,7 @@ public class ManageStreamTest
             var stream1 = await js.GetStreamAsync("events", cancellationToken: cancellationToken);
             Assert.Equal(-1, stream1.Info.Config.MaxMsgs);
 
-            var stream2 = await js.UpdateStreamAsync(new StreamUpdateRequest { Name = "events", MaxMsgs = 10 }, cancellationToken);
+            var stream2 = await js.UpdateStreamAsync(new StreamConfig { Name = "events", MaxMsgs = 10 }, cancellationToken);
             Assert.Equal(10, stream2.Info.Config.MaxMsgs);
 
             var stream3 = await js.GetStreamAsync("events", cancellationToken: cancellationToken);


### PR DESCRIPTION
StreamUpdateRequest was a placeholder class inheriting StreamConfig and adding no value to it. Using StreamUpdateRequest in update stream methods and StreamConfig in creation method was inconsistent and it was causing unnecessary object creation in some cases forcing the end developer to map everything from config object.