### PR TITLE
Adding support for the no_responders feature.

### DIFF
--- a/src/NATS.Client.Core/Internal/ClientOpts.cs
+++ b/src/NATS.Client.Core/Internal/ClientOpts.cs
@@ -21,7 +21,6 @@ internal sealed class ClientOpts
         Password = opts.AuthOpts.Password;
         AuthToken = opts.AuthOpts.Token;
         JWT = opts.AuthOpts.Jwt;
-        NoResponders = opts.NoResponders;
     }
 
     /// <summary>Optional boolean. If set to true, the server (version 1.2.0+) will not send originating messages from this connection to its own subscriptions. Clients should set this to true only for server supporting this feature, which is when proto in the INFO protocol is set to at least 1.</summary>
@@ -89,7 +88,7 @@ internal sealed class ClientOpts
     public bool Headers { get; init; } = false;
 
     [JsonPropertyName("no_responders")]
-    public bool NoResponders { get; init; } = false;
+    public bool NoResponders { get; init; } = true;
 
     public static ClientOpts Create(NatsOpts opts)
     {

--- a/src/NATS.Client.Core/Internal/ClientOpts.cs
+++ b/src/NATS.Client.Core/Internal/ClientOpts.cs
@@ -21,6 +21,7 @@ internal sealed class ClientOpts
         Password = opts.AuthOpts.Password;
         AuthToken = opts.AuthOpts.Token;
         JWT = opts.AuthOpts.Jwt;
+        NoResponders = opts.NoResponders;
     }
 
     /// <summary>Optional boolean. If set to true, the server (version 1.2.0+) will not send originating messages from this connection to its own subscriptions. Clients should set this to true only for server supporting this feature, which is when proto in the INFO protocol is set to at least 1.</summary>

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -32,7 +32,7 @@ public partial class NatsConnection
         {
             if (sub.Msgs.TryRead(out var msg))
             {
-                if (msg.Headers?.Code == 503)
+                if (msg.IsNoRespondersError)
                 {
                     throw new NatsNoRespondersException();
                 }

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -32,6 +32,11 @@ public partial class NatsConnection
         {
             if (sub.Msgs.TryRead(out var msg))
             {
+                if (msg.Headers?.Code == 503)
+                {
+                    throw new NatsNoRespondersException();
+                }
+
                 return msg;
             }
         }

--- a/src/NATS.Client.Core/NatsException.cs
+++ b/src/NATS.Client.Core/NatsException.cs
@@ -21,6 +21,14 @@ public sealed class NatsNoReplyException : NatsException
     }
 }
 
+public sealed class NatsNoRespondersException : NatsException
+{
+    public NatsNoRespondersException()
+        : base("No responders")
+    {
+    }
+}
+
 public sealed class NatsServerException : NatsException
 {
     public NatsServerException(string error)

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -60,9 +60,9 @@ public readonly record struct NatsMsg<T>(
         }
 
         var size = subject.Length
-            + (replyTo?.Length ?? 0)
-            + (headersBuffer?.Length ?? 0)
-            + payloadBuffer.Length;
+                   + (replyTo?.Length ?? 0)
+                   + (headersBuffer?.Length ?? 0)
+                   + payloadBuffer.Length;
 
         return new NatsMsg<T>(subject, replyTo, (int)size, headers, data, connection);
     }
@@ -141,4 +141,6 @@ public readonly record struct NatsMsg<T>(
             throw new NatsException("unable to send reply; ReplyTo is empty");
         }
     }
+
+    public bool IsNoRespondersError => Headers?.Code == 503;
 }

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -30,6 +30,8 @@ public readonly record struct NatsMsg<T>(
     T? Data,
     INatsConnection? Connection)
 {
+    public bool IsNoRespondersError => Headers?.Code == 503;
+
     internal static NatsMsg<T> Build(
         string subject,
         string? replyTo,
@@ -141,6 +143,4 @@ public readonly record struct NatsMsg<T>(
             throw new NatsException("unable to send reply; ReplyTo is empty");
         }
     }
-
-    public bool IsNoRespondersError => Headers?.Code == 503;
 }

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -44,8 +44,6 @@ public sealed record NatsOpts
 
     public int MaxPingOut { get; init; } = 2;
 
-    public bool NoResponders { get; set; } = false;
-
     /// <summary>
     /// Minimum amount of time to wait between reconnect attempts. (default: 2s)
     /// </summary>

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -44,6 +44,8 @@ public sealed record NatsOpts
 
     public int MaxPingOut { get; init; } = 2;
 
+    public bool NoResponders { get; set; } = false;
+
     /// <summary>
     /// Minimum amount of time to wait between reconnect attempts. (default: 2s)
     /// </summary>

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -59,7 +59,7 @@ public abstract partial class NatsConnectionTest
         await using var server = NatsServer.StartWithTrace(_output);
 
         // For no_responders to work we need to the publisher and subscriber to be using the same connection
-        await using var subConnection = server.CreateClientConnection(NatsOpts.Default with { NoResponders = true });
+        await using var subConnection = server.CreateClientConnection();
 
         var signalComplete = new WaitSignal();
         var replyToAddress = subConnection.NewInbox();

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -150,6 +150,13 @@ public abstract partial class NatsConnectionTest
                 return;
             }
 
+            // Trigger a timeout
+            if (m.Data == 11)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(6));
+                return;
+            }
+
             await m.ReplyAsync(text + m.Data);
         });
 
@@ -168,7 +175,7 @@ public abstract partial class NatsConnectionTest
 
         // timeout check
         await Assert.ThrowsAsync<NatsNoReplyException>(async () =>
-            await pubConnection.RequestAsync<int, string>("foo", 10, replyOpts: new NatsSubOpts { Timeout = TimeSpan.FromSeconds(1) }));
+            await pubConnection.RequestAsync<int, string>(subject, 11, replyOpts: new NatsSubOpts { Timeout = TimeSpan.FromSeconds(1) }));
 
         await sub.DisposeAsync();
         await reg;

--- a/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
@@ -67,6 +67,18 @@ public class RequestReplyTest
     }
 
     [Fact]
+    public async Task Request_reply_no_responders_test()
+    {
+        await using var server = NatsServer.Start();
+
+        // Enable no responders, and do not set a timeout. We should get a response with a 503 header code.
+        {
+            await using var nats = server.CreateClientConnection(NatsOpts.Default with { NoResponders = true });
+            await Assert.ThrowsAsync<NatsNoRespondersException>(async () => await nats.RequestAsync<int, int>(Guid.NewGuid().ToString(), 0));
+        }
+    }
+
+    [Fact]
     public async Task Request_reply_many_test()
     {
         const int msgs = 10;

--- a/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
@@ -50,8 +50,18 @@ public class RequestReplyTest
                 RequestTimeout = TimeSpan.FromSeconds(1),
             });
 
+            var sub = await nats.SubscribeCoreAsync<int>("foo");
+            var reg = sub.Register(async msg =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            });
+            await nats.PingAsync();
+
             await Assert.ThrowsAsync<NatsNoReplyException>(async () =>
                 await nats.RequestAsync<int, int>("foo", 0));
+
+            await sub.DisposeAsync();
+            await reg;
         }
 
         // Cancellation token usage
@@ -59,10 +69,20 @@ public class RequestReplyTest
             await using var nats = server.CreateClientConnection();
 
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            var sub = await nats.SubscribeCoreAsync<int>("foo");
+            var reg = sub.Register(async msg =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            });
+            await nats.PingAsync();
+
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             {
                 await nats.RequestAsync<int, int>("foo", 0, cancellationToken: cts.Token);
             });
+
+            await sub.DisposeAsync();
+            await reg;
         }
     }
 

--- a/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
@@ -73,7 +73,7 @@ public class RequestReplyTest
 
         // Enable no responders, and do not set a timeout. We should get a response with a 503 header code.
         {
-            await using var nats = server.CreateClientConnection(NatsOpts.Default with { NoResponders = true });
+            await using var nats = server.CreateClientConnection();
             await Assert.ThrowsAsync<NatsNoRespondersException>(async () => await nats.RequestAsync<int, int>(Guid.NewGuid().ToString(), 0));
         }
     }


### PR DESCRIPTION
This solves #258

* Feature can be enabled via. `NatsOpts.NoResponders` (defaults to `false` like before the PR)
* Throws a new `NatsNoRespondersException` if triggered cia. `RequestAsync`, but not if triggered via `PublishAsync`.
* A normal subscriber that receives a message due to `no_responders`, in case the client is using his own `request-reply` mechanism through PubSub and `reply_to`, does NOT throw an exception but the subscriber receives an empty message with `msg.Headers.Code` equal to `503`.
  * We could also have this throw an exception but I felt it didn't make sense outside of `RequestAsync` but that's open for discussion. It could even be another configuration value for NatsOpts (`bool ThrowOnNoResponders`) so let's discuss that.
* Added tests for both `RequestAsync` and custom `PubSub` to trigger the behavior.
* Also ran `dotnet format` which formatted some unrelated files.
