### PR TITLE
Separate docs updates and release workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+﻿name: Update Docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  update-docs:
+    name: docfx
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, '[nats:update-docs]')
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.x'
+
+      - run: dotnet tool update -g docfx
+
+      - run: docfx docs/docfx.json
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,9 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 jobs:
   nuget:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     name: dotnet
     runs-on: ubuntu-latest
     steps:
@@ -52,23 +47,6 @@ jobs:
           cd dist
           # this should upload snupkgs in the same folder
           dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k "${{ secrets.NUGET_API_KEY }}" --skip-duplicate
-
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        run: dotnet tool update -g docfx
-
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        run: docfx docs/docfx.json
-
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: docs/_site
-
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
 
       - if: ${{ fromJSON(steps.tag.outputs.create) }}
         name: Tag


### PR DESCRIPTION
That way we can update documentation in between releases as well as have more frequent preview releases without documentation updates.