### PR TITLE
Message flags

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -62,8 +62,13 @@ public partial class NatsConnection
         {
             while (sub.Msgs.TryRead(out var msg))
             {
+                if (msg.IsNoRespondersError)
+                {
+                    throw new NatsNoRespondersException();
+                }
+
                 // Received end of stream sentinel
-                if (msg.Data is null)
+                if (msg.HasNoPayload)
                 {
                     yield break;
                 }

--- a/tests/NATS.Client.Core.Tests/NatsMsgTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsMsgTest.cs
@@ -1,0 +1,65 @@
+﻿using System.Buffers;
+using System.Text;
+
+namespace NATS.Client.Core.Tests;
+
+public class NatsMsgTest
+{
+    [Fact]
+    public void Empty_payload()
+    {
+        var msg1 = NatsMsg<int>.Build(
+            subject: "foo",
+            replyTo: "bar",
+            headersBuffer: null,
+            payloadBuffer: new ReadOnlySequence<byte>(new byte[] { }),
+            connection: null,
+            headerParser: new NatsHeaderParser(Encoding.UTF8),
+            NatsDefaultSerializer<int>.Default);
+        Assert.True(msg1.HasNoPayload);
+
+        var msg2 = NatsMsg<int>.Build(
+            subject: "foo",
+            replyTo: "bar",
+            headersBuffer: null,
+            payloadBuffer: new ReadOnlySequence<byte>(new[] { (byte)'0' }),
+            connection: null,
+            headerParser: new NatsHeaderParser(Encoding.UTF8),
+            NatsDefaultSerializer<int>.Default);
+        Assert.False(msg2.HasNoPayload);
+    }
+
+    [Fact]
+    public void No_responders()
+    {
+        var msg1 = NatsMsg<int>.Build(
+            subject: "foo",
+            replyTo: "bar",
+            headersBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("NATS/1.0 503\r\n\r\n")),
+            payloadBuffer: new ReadOnlySequence<byte>(new byte[] { }),
+            connection: null,
+            headerParser: new NatsHeaderParser(Encoding.UTF8),
+            NatsDefaultSerializer<int>.Default);
+        Assert.True(msg1.IsNoRespondersError);
+
+        var msg2 = NatsMsg<int>.Build(
+            subject: "foo",
+            replyTo: "bar",
+            headersBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("NATS/1.0 503\r\n\r\n")),
+            payloadBuffer: new ReadOnlySequence<byte>(new[] { (byte)'0' }),
+            connection: null,
+            headerParser: new NatsHeaderParser(Encoding.UTF8),
+            NatsDefaultSerializer<int>.Default);
+        Assert.False(msg2.IsNoRespondersError);
+
+        var msg3 = NatsMsg<int>.Build(
+            subject: "foo",
+            replyTo: "bar",
+            headersBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("NATS/1.0 503\r\nk: v\r\n\r\n")),
+            payloadBuffer: new ReadOnlySequence<byte>(new byte[] { }),
+            connection: null,
+            headerParser: new NatsHeaderParser(Encoding.UTF8),
+            NatsDefaultSerializer<int>.Default);
+        Assert.False(msg3.IsNoRespondersError);
+    }
+}


### PR DESCRIPTION
Added message flags to indicate a couple of states and have room for future ones. Since NatsMsg is a struct we must keep its size in check. Flags added as a byte allows us to define upto seven flags only adding one byte to the struct size.