### PR TITLE
Added slow consumer events

### DIFF
--- a/src/NATS.Client.Core/INatsError.cs
+++ b/src/NATS.Client.Core/INatsError.cs
@@ -1,0 +1,34 @@
+namespace NATS.Client.Core;
+
+public interface INatsError
+{
+    string Message { get; }
+}
+
+public sealed class MessageDroppedError : INatsError
+{
+    public MessageDroppedError(NatsSubBase subscription, int pending, string subject, string? replyTo, NatsHeaders? headers, object? data)
+    {
+        Subscription = subscription;
+        Pending = pending;
+        Subject = subject;
+        ReplyTo = replyTo;
+        Headers = headers;
+        Data = data;
+        Message = $"Dropped message from {subject} with {pending} pending messages";
+    }
+
+    public NatsSubBase Subscription { get; }
+
+    public int Pending { get; }
+
+    public string Subject { get; }
+
+    public string? ReplyTo { get; }
+
+    public NatsHeaders? Headers { get; }
+
+    public object? Data { get; }
+
+    public string Message { get; }
+}

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -79,9 +79,9 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
         _logger = opts.LoggerFactory.CreateLogger<NatsConnection>();
         _clientOpts = ClientOpts.Create(Opts);
         HeaderParser = new NatsHeaderParser(opts.HeaderEncoding);
-        _defaultSubscriptionChannelOpts = new BoundedChannelOptions(opts.SubscriptionChannelCapacity)
+        _defaultSubscriptionChannelOpts = new BoundedChannelOptions(opts.SubPendingChannelCapacity)
         {
-            FullMode = opts.SubscriptionChannelFullMode,
+            FullMode = opts.SubPendingChannelFullMode,
             SingleWriter = true,
             SingleReader = false,
             AllowSynchronousContinuations = false,

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NATS.Client.Core.Internal;
@@ -93,6 +94,25 @@ public sealed record NatsOpts
     /// subsequent reconnect attempts if server returns the same auth error twice.
     /// </summary>
     public bool IgnoreAuthErrorAbort { get; init; } = false;
+
+    /// <summary>
+    /// This value will be used for subscriptions internal bounded message channel capacity.
+    /// The default subscriber pending message limit is 65536.
+    /// </summary>
+    public int SubscriptionChannelCapacity { get; init; } = 65536;
+
+    /// <summary>
+    /// This value will be used for subscriptions internal bounded message channel <c>FullMode</c>.
+    /// The default is to drop oldest message when full (<c>BoundedChannelFullMode.DropOldest</c>).
+    /// </summary>
+    /// <remarks>
+    /// If the client reaches this internal limit (bounded channel capacity), by default it will drop messages
+    /// and continue to process new messages. This is aligned with NATS at most once delivery. It is up to
+    /// the application to detect the missing messages (<seealso cref="NatsConnection.OnError"/>) and recover
+    /// from this condition or set a different default such as <c>BoundedChannelFullMode.Wait</c> in which
+    /// case it might risk server disconnecting the client as a slow consumer.
+    /// </remarks>
+    public BoundedChannelFullMode SubscriptionChannelFullMode { get; init; } = BoundedChannelFullMode.DropOldest;
 
     internal NatsUri[] GetSeedUris()
     {

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -97,13 +97,13 @@ public sealed record NatsOpts
 
     /// <summary>
     /// This value will be used for subscriptions internal bounded message channel capacity.
-    /// The default subscriber pending message limit is 65536.
+    /// The default subscriber pending message limit is 1024.
     /// </summary>
-    public int SubscriptionChannelCapacity { get; init; } = 65536;
+    public int SubPendingChannelCapacity { get; init; } = 1024;
 
     /// <summary>
     /// This value will be used for subscriptions internal bounded message channel <c>FullMode</c>.
-    /// The default is to drop oldest message when full (<c>BoundedChannelFullMode.DropOldest</c>).
+    /// The default is to drop newest message when full (<c>BoundedChannelFullMode.DropNewest</c>).
     /// </summary>
     /// <remarks>
     /// If the client reaches this internal limit (bounded channel capacity), by default it will drop messages
@@ -112,7 +112,7 @@ public sealed record NatsOpts
     /// from this condition or set a different default such as <c>BoundedChannelFullMode.Wait</c> in which
     /// case it might risk server disconnecting the client as a slow consumer.
     /// </remarks>
-    public BoundedChannelFullMode SubscriptionChannelFullMode { get; init; } = BoundedChannelFullMode.DropOldest;
+    public BoundedChannelFullMode SubPendingChannelFullMode { get; init; } = BoundedChannelFullMode.DropNewest;
 
     internal NatsUri[] GetSeedUris()
     {

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -21,7 +21,7 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
     {
         _msgs = Channel.CreateBounded<NatsMsg<T>>(
             connection.GetChannelOpts(connection.Opts, opts?.ChannelOpts),
-            msg => connection.MessageDropped(this, _msgs?.Reader.Count ?? 0, msg));
+            msg => Connection.MessageDropped(this, _msgs?.Reader.Count ?? 0, msg));
 
         Serializer = serializer;
     }

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -20,7 +20,8 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
         : base(connection, manager, subject, queueGroup, opts, cancellationToken)
     {
         _msgs = Channel.CreateBounded<NatsMsg<T>>(
-            NatsSubUtils.GetChannelOpts(opts?.ChannelOpts));
+            connection.GetChannelOpts(connection.Opts, opts?.ChannelOpts),
+            msg => connection.MessageDropped(this, _msgs?.Reader.Count ?? 0, msg));
 
         Serializer = serializer;
     }
@@ -63,38 +64,4 @@ public class NatsSubException : NatsException
     public Memory<byte> Payload { get; }
 
     public Memory<byte> Headers { get; }
-}
-
-internal sealed class NatsSubUtils
-{
-    private static readonly BoundedChannelOptions DefaultChannelOpts =
-        new BoundedChannelOptions(1_000)
-        {
-            FullMode = BoundedChannelFullMode.Wait,
-            SingleWriter = true,
-            SingleReader = false,
-            AllowSynchronousContinuations = false,
-        };
-
-    internal static BoundedChannelOptions GetChannelOpts(
-        NatsSubChannelOpts? subChannelOpts)
-    {
-        if (subChannelOpts is { } overrideOpts)
-        {
-            return new BoundedChannelOptions(overrideOpts.Capacity ??
-                                             DefaultChannelOpts.Capacity)
-            {
-                AllowSynchronousContinuations =
-                    DefaultChannelOpts.AllowSynchronousContinuations,
-                FullMode =
-                    overrideOpts.FullMode ?? DefaultChannelOpts.FullMode,
-                SingleWriter = DefaultChannelOpts.SingleWriter,
-                SingleReader = DefaultChannelOpts.SingleReader,
-            };
-        }
-        else
-        {
-            return DefaultChannelOpts;
-        }
-    }
 }

--- a/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
+++ b/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
@@ -18,6 +18,11 @@ public class NatsSubTests
                 // Subscription is not being disposed here
                 var natsSub = await nats.SubscribeCoreAsync<string>("foo");
                 Assert.That(natsSub.Subject, Is.EqualTo("foo"));
+                dotMemory.Check(memory =>
+                {
+                    var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
+                    Assert.That(count, Is.EqualTo(1));
+                });
             }
 
             Isolator().GetAwaiter().GetResult();
@@ -26,7 +31,7 @@ public class NatsSubTests
 
             dotMemory.Check(memory =>
             {
-                var count = memory.GetObjects(where => where.Type.Is<NatsSubUtils>()).ObjectsCount;
+                var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
                 Assert.That(count, Is.EqualTo(0));
             });
         }

--- a/tests/NATS.Client.Core.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.Core.Tests/SlowConsumerTest.cs
@@ -10,7 +10,7 @@ public class SlowConsumerTest
     public async Task Slow_consumer()
     {
         await using var server = NatsServer.Start();
-        var nats = server.CreateClientConnection(new NatsOpts { SubscriptionChannelCapacity = 3 });
+        var nats = server.CreateClientConnection(new NatsOpts { SubPendingChannelCapacity = 3 });
 
         var lost = 0;
         nats.OnError += (_, e) =>

--- a/tests/NATS.Client.Core.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.Core.Tests/SlowConsumerTest.cs
@@ -1,0 +1,85 @@
+namespace NATS.Client.Core.Tests;
+
+public class SlowConsumerTest
+{
+    private readonly ITestOutputHelper _output;
+
+    public SlowConsumerTest(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task Slow_consumer()
+    {
+        await using var server = NatsServer.Start();
+        var nats = server.CreateClientConnection(new NatsOpts { SubscriptionChannelCapacity = 3 });
+
+        var lost = 0;
+        nats.OnError += (_, e) =>
+        {
+            if (e is MessageDroppedError dropped)
+            {
+                Interlocked.Increment(ref lost);
+                _output.WriteLine($"LOST {dropped.Data}");
+            }
+        };
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var cancellationToken = cts.Token;
+
+        var sync = 0;
+        var end = 0;
+        var count = 0;
+        var signal = new WaitSignal();
+        var subscription = Task.Run(
+            async () =>
+            {
+                await foreach (var msg in nats.SubscribeAsync<string>("foo.>", cancellationToken: cancellationToken))
+                {
+                    if (msg.Subject == "foo.sync")
+                    {
+                        Interlocked.Increment(ref sync);
+                        continue;
+                    }
+
+                    if (msg.Subject == "foo.end")
+                    {
+                        Interlocked.Increment(ref end);
+                        break;
+                    }
+
+                    await signal;
+
+                    Interlocked.Increment(ref count);
+                    _output.WriteLine($"GOOD {msg.Data}");
+                }
+            },
+            cancellationToken);
+
+        await Retry.Until(
+            "subscription is ready",
+            () => Volatile.Read(ref sync) > 0,
+            async () => await nats.PublishAsync("foo.sync", cancellationToken: cancellationToken));
+
+        for (var i = 0; i < 10; i++)
+        {
+            await nats.PublishAsync("foo.data", $"A{i}", cancellationToken: cancellationToken);
+        }
+
+        signal.Pulse();
+
+        for (var i = 0; i < 10; i++)
+        {
+            await nats.PublishAsync("foo.data", $"B{i}", cancellationToken: cancellationToken);
+        }
+
+        await Retry.Until(
+            "subscription is ended",
+            () => Volatile.Read(ref end) > 0,
+            async () => await nats.PublishAsync("foo.end", cancellationToken: cancellationToken));
+
+        await subscription;
+
+        // we should've lost most of the messages because of the low channel capacity
+        Volatile.Read(ref count).Should().BeLessThan(20);
+        Volatile.Read(ref lost).Should().BeGreaterThan(0);
+    }
+}

--- a/tests/NATS.Client.Perf/Program.cs
+++ b/tests/NATS.Client.Perf/Program.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Threading.Channels;
 using NATS.Client.Core;
 using NATS.Client.Core.Tests;
 
@@ -23,7 +24,11 @@ await using var server = NatsServer.Start();
 Console.WriteLine("\nRunning nats bench");
 var natsBenchTotalMsgs = RunNatsBench(server.ClientUrl, t);
 
-await using var nats1 = server.CreateClientConnection();
+await using var nats1 = server.CreateClientConnection(new NatsOpts
+{
+    // don't drop messages
+    SubPendingChannelFullMode = BoundedChannelFullMode.Wait,
+});
 await using var nats2 = server.CreateClientConnection();
 
 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));


### PR DESCRIPTION
Slow consumers are subscriptions which are unable to process their messages fast enough. When the internal subscription channel is full oldest messages should be dropped and new messages should continued to be processed. This is aligned with NATS at most once delivery.

See also https://docs.nats.io/running-a-nats-service/nats_admin/slow_consumers