### PR TITLE
handle no responders in NatsSubBase

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -10,6 +10,18 @@ public partial class NatsConnection
     /// <inheritdoc />
     public string NewInbox() => NewInbox(InboxPrefix);
 
+    private static readonly NatsSubOpts ReplyOptsDefault = new NatsSubOpts
+    {
+        MaxMsgs = 1,
+        ThrowIfNoResponders = true,
+    };
+
+    private static readonly NatsSubOpts ReplyManyOptsDefault = new NatsSubOpts
+    {
+        StopOnEmptyMsg = true,
+        ThrowIfNoResponders = true,
+    };
+
     /// <inheritdoc />
     public async ValueTask<NatsMsg<TReply>> RequestAsync<TRequest, TReply>(
         string subject,
@@ -98,14 +110,18 @@ public partial class NatsConnection
 
     private NatsSubOpts SetReplyOptsDefaults(NatsSubOpts? replyOpts)
     {
-        var opts = replyOpts ?? new NatsSubOpts { MaxMsgs = 1 };
+        var opts = replyOpts ?? ReplyOptsDefault;
+        if (!opts.MaxMsgs.HasValue)
+        {
+            opts = opts with { MaxMsgs = 1 };
+        }
+
         return SetBaseReplyOptsDefaults(opts);
     }
 
     private NatsSubOpts SetReplyManyOptsDefaults(NatsSubOpts? replyOpts)
     {
-        var opts = replyOpts ?? new NatsSubOpts();
-
+        var opts = replyOpts ?? ReplyManyOptsDefault;
         if (!opts.StopOnEmptyMsg.HasValue)
         {
             opts = opts with { StopOnEmptyMsg = true };

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -7,8 +7,6 @@ namespace NATS.Client.Core;
 
 public partial class NatsConnection
 {
-    private static readonly NatsSubOpts DefaultReplyOpts = new() { MaxMsgs = 1 };
-
     /// <inheritdoc />
     public string NewInbox() => NewInbox(InboxPrefix);
 
@@ -23,20 +21,14 @@ public partial class NatsConnection
         NatsSubOpts? replyOpts = default,
         CancellationToken cancellationToken = default)
     {
-        var opts = SetReplyOptsDefaults(replyOpts);
-
-        await using var sub = await RequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, opts, cancellationToken)
+        replyOpts = SetReplyOptsDefaults(replyOpts);
+        await using var sub = await RequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)
             .ConfigureAwait(false);
 
         if (await sub.Msgs.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
             if (sub.Msgs.TryRead(out var msg))
             {
-                if (msg.IsNoRespondersError)
-                {
-                    throw new NatsNoRespondersException();
-                }
-
                 return msg;
             }
         }
@@ -55,6 +47,7 @@ public partial class NatsConnection
         NatsSubOpts? replyOpts = default,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        replyOpts = SetReplyManyOptsDefaults(replyOpts);
         await using var sub = await RequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)
             .ConfigureAwait(false);
 
@@ -62,12 +55,6 @@ public partial class NatsConnection
         {
             while (sub.Msgs.TryRead(out var msg))
             {
-                // Received end of stream sentinel
-                if (msg.Data is null)
-                {
-                    yield break;
-                }
-
                 yield return msg;
             }
         }
@@ -111,11 +98,32 @@ public partial class NatsConnection
 
     private NatsSubOpts SetReplyOptsDefaults(NatsSubOpts? replyOpts)
     {
-        var opts = replyOpts ?? DefaultReplyOpts;
+        var opts = replyOpts ?? new NatsSubOpts { MaxMsgs = 1 };
+        return SetBaseReplyOptsDefaults(opts);
+    }
 
-        if ((opts.Timeout ?? default) == default)
+    private NatsSubOpts SetReplyManyOptsDefaults(NatsSubOpts? replyOpts)
+    {
+        var opts = replyOpts ?? new NatsSubOpts();
+
+        if (!opts.StopOnEmptyMsg.HasValue)
+        {
+            opts = opts with { StopOnEmptyMsg = true };
+        }
+
+        return SetBaseReplyOptsDefaults(opts);
+    }
+
+    private NatsSubOpts SetBaseReplyOptsDefaults(NatsSubOpts opts)
+    {
+        if (!opts.Timeout.HasValue)
         {
             opts = opts with { Timeout = Opts.RequestTimeout };
+        }
+
+        if (!opts.ThrowIfNoResponders.HasValue)
+        {
+            opts = opts with { ThrowIfNoResponders = true };
         }
 
         return opts;

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -7,9 +7,6 @@ namespace NATS.Client.Core;
 
 public partial class NatsConnection
 {
-    /// <inheritdoc />
-    public string NewInbox() => NewInbox(InboxPrefix);
-
     private static readonly NatsSubOpts ReplyOptsDefault = new NatsSubOpts
     {
         MaxMsgs = 1,
@@ -21,6 +18,9 @@ public partial class NatsConnection
         StopOnEmptyMsg = true,
         ThrowIfNoResponders = true,
     };
+
+    /// <inheritdoc />
+    public string NewInbox() => NewInbox(InboxPrefix);
 
     /// <inheritdoc />
     public async ValueTask<NatsMsg<TReply>> RequestAsync<TRequest, TReply>(

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -30,8 +30,6 @@ public readonly record struct NatsMsg<T>(
     T? Data,
     INatsConnection? Connection)
 {
-    public bool IsNoRespondersError => Headers?.Code == 503;
-
     internal static NatsMsg<T> Build(
         string subject,
         string? replyTo,

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -15,6 +15,7 @@ public enum NatsSubEndReason
     MaxBytes,
     Timeout,
     IdleTimeout,
+    EmptyMsg,
     IdleHeartbeatTimeout,
     StartUpTimeout,
     Cancelled,
@@ -24,6 +25,7 @@ public enum NatsSubEndReason
 
 public abstract class NatsSubBase
 {
+    private static readonly byte[] NoRespondersHeaderSequence = { (byte)' ', (byte)'5', (byte)'0', (byte)'3' };
     private readonly ILogger _logger;
     private readonly bool _debug;
     private readonly ISubscriptionManager _manager;
@@ -192,6 +194,20 @@ public abstract class NatsSubBase
     public virtual async ValueTask ReceiveAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
         ResetIdleTimeout();
+
+        // check for empty payload conditions
+        if (payloadBuffer.Length == 0)
+        {
+            switch (Opts)
+            {
+            case { ThrowIfNoResponders: true } when headersBuffer is { Length: >= 12 } && headersBuffer.Value.Slice(8, 4).ToArray().SequenceEqual(NoRespondersHeaderSequence):
+                SetException(new NatsNoRespondersException());
+                return;
+            case { StopOnEmptyMsg: true }:
+                EndSubscription(NatsSubEndReason.EmptyMsg);
+                return;
+            }
+        }
 
         try
         {

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -200,7 +200,7 @@ public abstract class NatsSubBase
         {
             switch (Opts)
             {
-            case { ThrowIfNoResponders: true } when headersBuffer is { Length: >= 12 } && headersBuffer.Value.Slice(8, 4).ToArray().SequenceEqual(NoRespondersHeaderSequence):
+            case { ThrowIfNoResponders: true } when headersBuffer is { Length: >= 12 } && headersBuffer.Value.Slice(8, 4).ToSpan().SequenceEqual(NoRespondersHeaderSequence):
                 SetException(new NatsNoRespondersException());
                 return;
             case { StopOnEmptyMsg: true }:

--- a/src/NATS.Client.Core/NatsSubOpts.cs
+++ b/src/NATS.Client.Core/NatsSubOpts.cs
@@ -43,6 +43,26 @@ public record NatsSubOpts
     public TimeSpan? IdleTimeout { get; init; }
 
     /// <summary>
+    /// If true, end the subscription upon receiving an empty message.
+    /// The empty message will not be delivered to the subscription.
+    /// </summary>
+    /// <remarks>
+    /// If not set, all published messages will be received until explicitly
+    /// unsubscribed or disposed.
+    /// </remarks>
+    public bool? StopOnEmptyMsg { get; init; }
+
+    /// <summary>
+    /// If true, throw an exception if a no responders status message is received.
+    /// The no responders status message will not be delivered to the subscription.
+    /// </summary>
+    /// <remarks>
+    /// If not set, all published messages will be received until explicitly
+    /// unsubscribed or disposed.
+    /// </remarks>
+    public bool? ThrowIfNoResponders { get; init; }
+
+    /// <summary>
     /// Allows Configuration of <see cref="Channel"/> options for a subscription.
     /// </summary>
     public NatsSubChannelOpts? ChannelOpts { get; init; }

--- a/src/NATS.Client.Core/NatsSubOpts.cs
+++ b/src/NATS.Client.Core/NatsSubOpts.cs
@@ -53,7 +53,8 @@ public record NatsSubOpts
     public bool? StopOnEmptyMsg { get; init; }
 
     /// <summary>
-    /// If true, throw an exception if a no responders status message is received.
+    /// If true, end the subscription and throw an exception if a
+    /// no responders status message is received.
     /// The no responders status message will not be delivered to the subscription.
     /// </summary>
     /// <remarks>

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -133,6 +133,9 @@ public partial class NatsJSContext
                         // without the timeout the publish call will hang forever since the server
                         // which received the request won't be there to respond anymore.
                         Timeout = Connection.Opts.RequestTimeout,
+
+                        // If JetStream is disabled, a no responders error will be returned
+                        ThrowIfNoResponders = true,
                     },
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -141,11 +144,6 @@ public partial class NatsJSContext
             {
                 while (sub.Msgs.TryRead(out var msg))
                 {
-                    if (msg.IsNoRespondersError)
-                    {
-                        throw new NatsNoRespondersException();
-                    }
-
                     if (msg.Data == null)
                     {
                         throw new NatsJSException("No response data received");

--- a/tests/NATS.Client.CheckNativeAot/Program.cs
+++ b/tests/NATS.Client.CheckNativeAot/Program.cs
@@ -42,6 +42,9 @@ async Task RequestReplyTests()
         await msg.ReplyAsync<int?>(null); // sentinel
     });
 
+    // make sure the sub has started
+    await nats.PingAsync();
+
     var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
     var results = new[] { 2, 3, 4 };
     var count = 0;

--- a/tests/NATS.Client.CheckNativeAot/Program.cs
+++ b/tests/NATS.Client.CheckNativeAot/Program.cs
@@ -42,7 +42,7 @@ async Task RequestReplyTests()
         await msg.ReplyAsync<int?>(null); // sentinel
     });
 
-    // make sure the sub has started
+    // make sure subs have started
     await nats.PingAsync();
 
     var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -310,6 +310,9 @@ async Task ServicesTests()
         handler: _ => ValueTask.CompletedTask,
         cancellationToken: cancellationToken);
 
+    // make sure subs have started
+    await nats.PingAsync();
+
     // Check that the endpoints are registered correctly
     {
         var info = (await nats.FindServicesAsync("$SRV.INFO.s1", 1, NatsSrvJsonSerializer<InfoResponse>.Default, cancellationToken)).First();
@@ -347,6 +350,9 @@ async Task ServicesTests()
         handler: _ => ValueTask.CompletedTask,
         metadata: new Dictionary<string, string> { { "ep-k1", "ep-v1" } },
         cancellationToken: cancellationToken);
+
+    // make sure subs have started
+    await nats.PingAsync();
 
     // Check default queue group and stats handler
     {
@@ -408,6 +414,9 @@ async Task ServicesTests2()
             await m.ReplyAsync(m.Data * m.Data, cancellationToken: cancellationToken);
         },
         cancellationToken: cancellationToken);
+
+    // make sure subs have started
+    await nats.PingAsync();
 
     var info = (await nats.FindServicesAsync("$SRV.INFO", 1, NatsSrvJsonSerializer<InfoResponse>.Default, cancellationToken)).First();
     AssertSingle(info.Endpoints);


### PR DESCRIPTION
Handles No Responders in `NatsSubBase`, pre-de-serialization

Also handles `StopOnEmptyMsg`

This prevents the library from ever needing to check `msg.Data` for an Empty value
