### PR TITLE
move string-based PEM loading to callbacks

### DIFF
--- a/src/NATS.Client.Core/Internal/TlsCerts.cs
+++ b/src/NATS.Client.Core/Internal/TlsCerts.cs
@@ -1,36 +1,56 @@
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
-using System.Text.RegularExpressions;
 
 namespace NATS.Client.Core.Internal;
 
 internal class TlsCerts
 {
-    private static readonly Regex PemRegex = new(@"^\s*-{5}BEGIN\s+([^-]+)-{5}[A-Za-z0-9=+/\s\r\n]+-{5}END\s+\1-{5}\s*$", RegexOptions.Singleline | RegexOptions.Compiled);
+    public X509Certificate2Collection? CaCerts { get; private set; }
 
-    public TlsCerts(NatsTlsOpts tlsOpts)
+    public X509Certificate2Collection? ClientCerts { get; private set; }
+
+    public static async ValueTask<TlsCerts> FromNatsTlsOptsAsync(NatsTlsOpts tlsOpts)
     {
+        var tlsCerts = new TlsCerts();
         if (tlsOpts.Mode == TlsMode.Disable)
         {
-            return;
+            // no certs when disabled
+            return tlsCerts;
         }
 
-        if ((tlsOpts.CertFile != default && tlsOpts.KeyFile == default) ||
-            (tlsOpts.KeyFile != default && tlsOpts.CertFile == default))
+        // validation
+        switch (tlsOpts)
         {
+        case { CertFile: not null, KeyFile: null } or { KeyFile: not null, CertFile: null }:
             throw new ArgumentException("NatsTlsOpts.CertFile and NatsTlsOpts.KeyFile must both be set");
+        case { CertFile: not null, KeyFile: not null, LoadClientCert: not null }:
+            throw new ArgumentException("NatsTlsOpts.CertFile/KeyFile and NatsTlsOpts.LoadClientCert cannot both be set");
+        case { CaFile: not null, LoadCaCerts: not null }:
+            throw new ArgumentException("NatsTlsOpts.CaFile and NatsTlsOpts.LoadCaCerts cannot both be set");
         }
 
+        // ca certificates
         if (tlsOpts.CaFile != default)
         {
-            CaCerts = new X509Certificate2Collection();
-            CaCerts.ImportFromPem(ReadPemStringOrFile(tlsOpts.CaFile));
+            var caCerts = new X509Certificate2Collection();
+            caCerts.ImportFromPemFile(tlsOpts.CaFile);
+            tlsCerts.CaCerts = caCerts;
+        }
+        else if (tlsOpts.LoadCaCerts != default)
+        {
+            tlsCerts.CaCerts = await tlsOpts.LoadCaCerts().ConfigureAwait(false);
         }
 
-        if (tlsOpts.CertFile != default && tlsOpts.KeyFile != default)
+        // client certificates
+        var clientCert = tlsOpts switch
         {
-            var clientCert = X509Certificate2.CreateFromPem(ReadPemStringOrFile(tlsOpts.CertFile), ReadPemStringOrFile(tlsOpts.KeyFile));
+            { CertFile: not null, KeyFile: not null } => X509Certificate2.CreateFromPemFile(tlsOpts.CertFile, tlsOpts.KeyFile),
+            { LoadClientCert: not null } => await tlsOpts.LoadClientCert().ConfigureAwait(false),
+            _ => null,
+        };
 
+        if (clientCert != null)
+        {
             // On Windows, ephemeral keys/certificates do not work with schannel. e.g. unless stored in certificate store.
             // https://github.com/dotnet/runtime/issues/66283#issuecomment-1061014225
             // https://github.com/dotnet/runtime/blob/380a4723ea98067c28d54f30e1a652483a6a257a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs#L192-L197
@@ -41,13 +61,9 @@ internal class TlsCerts
                 ephemeral.Dispose();
             }
 
-            ClientCerts = new X509Certificate2Collection(clientCert);
+            tlsCerts.ClientCerts = new X509Certificate2Collection(clientCert);
         }
+
+        return tlsCerts;
     }
-
-    public X509Certificate2Collection? CaCerts { get; }
-
-    public X509Certificate2Collection? ClientCerts { get; }
-
-    private static string ReadPemStringOrFile(string input) => (PemRegex.IsMatch(input) ? input : File.ReadAllText(input)).Trim();
 }

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -288,8 +288,8 @@ public partial class NatsConnection : IAsyncDisposable, INatsConnection
                 throw new NatsException($"URI {uri} requires TLS but TlsMode is set to Disable");
         }
 
-        if (Opts.TlsOpts.HasTlsFile)
-            _tlsCerts = new TlsCerts(Opts.TlsOpts);
+        if (Opts.TlsOpts.HasTlsCerts)
+            _tlsCerts = await TlsCerts.FromNatsTlsOptsAsync(Opts.TlsOpts).ConfigureAwait(false);
 
         if (!Opts.AuthOpts.IsAnonymous)
         {

--- a/tests/NATS.Client.TestUtilities/NatsServer.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServer.cs
@@ -361,10 +361,8 @@ public class NatsServer : IAsyncDisposable
 
     public NatsOpts ClientOpts(NatsOpts opts)
     {
-        var tls = opts.TlsOpts ?? NatsTlsOpts.Default;
-
         var natsTlsOpts = Opts.EnableTls
-            ? tls with
+            ? opts.TlsOpts with
             {
                 CertFile = Opts.TlsClientCertFile,
                 KeyFile = Opts.TlsClientKeyFile,


### PR DESCRIPTION
Note - PR is to branch opened for #283 

Suggestion to move string-based PEM loading to callbacks, which will enable other functionality in callbacks too - different cert formats, private keys with passwords, load from external store, etc