### PR TITLE
TLS Check Certificate Revocation option

### DIFF
--- a/src/NATS.Client.Core/Internal/SslStreamConnection.cs
+++ b/src/NATS.Client.Core/Internal/SslStreamConnection.cs
@@ -178,7 +178,7 @@ internal sealed class SslStreamConnection : ISocketConnection
             ClientCertificates = _tlsCerts?.ClientCerts,
             LocalCertificateSelectionCallback = lcsCb,
             RemoteCertificateValidationCallback = rcsCb,
-            CertificateRevocationCheckMode = _tlsOpts.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+            CertificateRevocationCheckMode = _tlsOpts.CertificateRevocationCheckMode,
         };
 
         return options;

--- a/src/NATS.Client.Core/Internal/SslStreamConnection.cs
+++ b/src/NATS.Client.Core/Internal/SslStreamConnection.cs
@@ -178,6 +178,7 @@ internal sealed class SslStreamConnection : ISocketConnection
             ClientCertificates = _tlsCerts?.ClientCerts,
             LocalCertificateSelectionCallback = lcsCb,
             RemoteCertificateValidationCallback = rcsCb,
+            CertificateRevocationCheckMode = _tlsOpts.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
         };
 
         return options;

--- a/src/NATS.Client.Core/NatsTlsOpts.cs
+++ b/src/NATS.Client.Core/NatsTlsOpts.cs
@@ -77,6 +77,8 @@ public sealed record NatsTlsOpts
     /// <summary>When true, skip remote certificate verification and accept any server certificate</summary>
     public bool InsecureSkipVerify { get; init; }
 
+    /// <summary>Certificate revocation mode for certificate validation.</summary>
+    /// <value>One of the values in <see cref="T:System.Security.Cryptography.X509Certificates.X509RevocationMode" />. The default is <see langword="NoCheck" />.</value>
     public X509RevocationMode CertificateRevocationCheckMode { get; init; }
 
     /// <summary>TLS mode to use during connection</summary>

--- a/src/NATS.Client.Core/NatsTlsOpts.cs
+++ b/src/NATS.Client.Core/NatsTlsOpts.cs
@@ -77,7 +77,7 @@ public sealed record NatsTlsOpts
     /// <summary>When true, skip remote certificate verification and accept any server certificate</summary>
     public bool InsecureSkipVerify { get; init; }
 
-    public bool CheckCertificateRevocation { get; init; }
+    public X509RevocationMode CertificateRevocationCheckMode { get; init; }
 
     /// <summary>TLS mode to use during connection</summary>
     public TlsMode Mode { get; init; }

--- a/src/NATS.Client.Core/NatsTlsOpts.cs
+++ b/src/NATS.Client.Core/NatsTlsOpts.cs
@@ -77,6 +77,8 @@ public sealed record NatsTlsOpts
     /// <summary>When true, skip remote certificate verification and accept any server certificate</summary>
     public bool InsecureSkipVerify { get; init; }
 
+    public bool CheckCertificateRevocation { get; init; }
+
     /// <summary>TLS mode to use during connection</summary>
     public TlsMode Mode { get; init; }
 

--- a/tests/NATS.Client.Core.Tests/TlsClientTest.cs
+++ b/tests/NATS.Client.Core.Tests/TlsClientTest.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography.X509Certificates;
+
 namespace NATS.Client.Core.Tests;
 
 public class TlsClientTest
@@ -32,7 +34,7 @@ public class TlsClientTest
                 .Build());
 
         var clientOpts = server.ClientOpts(NatsOpts.Default with { Name = "tls-test-client" });
-        clientOpts = clientOpts with { TlsOpts = clientOpts.TlsOpts with { CheckCertificateRevocation = true } };
+        clientOpts = clientOpts with { TlsOpts = clientOpts.TlsOpts with { CertificateRevocationCheckMode = X509RevocationMode.Online } };
         await using var nats = new NatsConnection(clientOpts);
 
         // At the moment I don't know of a good way of checking if the revocation check is working


### PR DESCRIPTION
Looks like OCSP must-staple support is implemented in .NET7 and should be in .NET8. Not sure if .NET6 received a patch as well. https://github.com/dotnet/runtime/issues/33377