### PR TITLE
Fixed serialization problem in PublishModel/PublishHeaders examples

### DIFF
--- a/sandbox/Example.Core.PublishHeaders/Example.Core.PublishHeaders.csproj
+++ b/sandbox/Example.Core.PublishHeaders/Example.Core.PublishHeaders.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\NATS.Client.Core\NATS.Client.Core.csproj" />
+      <ProjectReference Include="..\..\src\NATS.Client.Serializers.Json\NATS.Client.Serializers.Json.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sandbox/Example.Core.PublishHeaders/Program.cs
+++ b/sandbox/Example.Core.PublishHeaders/Program.cs
@@ -7,7 +7,7 @@ var subject = "bar.xyz";
 var options = NatsOpts.Default with
 {
     LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
-    SerializerRegistry = new NatsJsonSerializerRegistry(),
+    SerializerRegistry = NatsJsonSerializerRegistry.Default,
 };
 
 Print("[CON] Connecting...\n");

--- a/sandbox/Example.Core.PublishHeaders/Program.cs
+++ b/sandbox/Example.Core.PublishHeaders/Program.cs
@@ -1,9 +1,14 @@
 // > nats sub bar.*
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
+using NATS.Client.Serializers.Json;
 
 var subject = "bar.xyz";
-var options = NatsOpts.Default with { LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()) };
+var options = NatsOpts.Default with
+{
+    LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
+    SerializerRegistry = new NatsJsonSerializerRegistry(),
+};
 
 Print("[CON] Connecting...\n");
 
@@ -12,7 +17,7 @@ await using var connection = new NatsConnection(options);
 for (var i = 0; i < 10; i++)
 {
     Print($"[PUB] Publishing to subject ({i}) '{subject}'...\n");
-    await connection.PublishAsync<Bar>(
+    await connection.PublishAsync(
         subject,
         new Bar { Id = i, Name = "Baz" },
         headers: new NatsHeaders { ["XFoo"] = $"bar{i}" });

--- a/sandbox/Example.Core.PublishModel/Example.Core.PublishModel.csproj
+++ b/sandbox/Example.Core.PublishModel/Example.Core.PublishModel.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\NATS.Client.Core\NATS.Client.Core.csproj" />
+      <ProjectReference Include="..\..\src\NATS.Client.Serializers.Json\NATS.Client.Serializers.Json.csproj" />
     </ItemGroup>
 
   <ItemGroup>

--- a/sandbox/Example.Core.PublishModel/Program.cs
+++ b/sandbox/Example.Core.PublishModel/Program.cs
@@ -6,7 +6,7 @@ using NATS.Client.Serializers.Json;
 var subject = "bar.xyz";
 var options = NatsOpts.Default with {
     LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
-    SerializerRegistry = new NatsJsonSerializerRegistry(),
+    SerializerRegistry = NatsJsonSerializerRegistry.Default,
 };
 
 Print("[CON] Connecting...\n");

--- a/sandbox/Example.Core.PublishModel/Program.cs
+++ b/sandbox/Example.Core.PublishModel/Program.cs
@@ -1,9 +1,13 @@
 // > nats sub bar.*
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
+using NATS.Client.Serializers.Json;
 
 var subject = "bar.xyz";
-var options = NatsOpts.Default with { LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()) };
+var options = NatsOpts.Default with {
+    LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
+    SerializerRegistry = new NatsJsonSerializerRegistry(),
+};
 
 Print("[CON] Connecting...\n");
 
@@ -12,7 +16,7 @@ await using var connection = new NatsConnection(options);
 for (var i = 0; i < 10; i++)
 {
     Print($"[PUB] Publishing to subject ({i}) '{subject}'...\n");
-    await connection.PublishAsync<Bar>(subject, new Bar { Id = i, Name = "Baz" });
+    await connection.PublishAsync(subject, new Bar { Id = i, Name = "Baz" });
 }
 
 void Print(string message)

--- a/sandbox/Example.Core.SubscribeHeaders/Example.Core.SubscribeHeaders.csproj
+++ b/sandbox/Example.Core.SubscribeHeaders/Example.Core.SubscribeHeaders.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\NATS.Client.Core\NATS.Client.Core.csproj" />
+      <ProjectReference Include="..\..\src\NATS.Client.Serializers.Json\NATS.Client.Serializers.Json.csproj" />
     </ItemGroup>
 
   <ItemGroup>

--- a/sandbox/Example.Core.SubscribeHeaders/Program.cs
+++ b/sandbox/Example.Core.SubscribeHeaders/Program.cs
@@ -1,11 +1,15 @@
 // > nats pub bar.xyz --count=10 "my_message_{{ Count }}" -H X-Foo:Baz
 
-using System.Text;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
+using NATS.Client.Serializers.Json;
 
 var subject = "bar.*";
-var options = NatsOpts.Default with { LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()) };
+var options = NatsOpts.Default with
+{
+    LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
+    SerializerRegistry = new NatsJsonSerializerRegistry(),
+};
 
 Print("[CON] Connecting...\n");
 
@@ -13,9 +17,9 @@ await using var connection = new NatsConnection(options);
 
 Print($"[SUB] Subscribing to subject '{subject}'...\n");
 
-await foreach (var msg in connection.SubscribeAsync<byte[]>(subject))
+await foreach (var msg in connection.SubscribeAsync<Bar>(subject))
 {
-    Print($"[RCV] {msg.Subject}: {Encoding.UTF8.GetString(msg.Data!)}\n");
+    Print($"[RCV] {msg.Subject}: {msg.Data!}\n");
     if (msg.Headers != null)
     {
         foreach (var (key, values) in msg.Headers)

--- a/sandbox/Example.Core.SubscribeHeaders/Program.cs
+++ b/sandbox/Example.Core.SubscribeHeaders/Program.cs
@@ -8,7 +8,7 @@ var subject = "bar.*";
 var options = NatsOpts.Default with
 {
     LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
-    SerializerRegistry = new NatsJsonSerializerRegistry(),
+    SerializerRegistry = NatsJsonSerializerRegistry.Default,
 };
 
 Print("[CON] Connecting...\n");

--- a/sandbox/Example.Core.SubscribeModel/Example.Core.SubscribeModel.csproj
+++ b/sandbox/Example.Core.SubscribeModel/Example.Core.SubscribeModel.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\NATS.Client.Core\NATS.Client.Core.csproj" />
+      <ProjectReference Include="..\..\src\NATS.Client.Serializers.Json\NATS.Client.Serializers.Json.csproj" />
     </ItemGroup>
 
   <ItemGroup>

--- a/sandbox/Example.Core.SubscribeModel/Program.cs
+++ b/sandbox/Example.Core.SubscribeModel/Program.cs
@@ -1,8 +1,13 @@
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
+using NATS.Client.Serializers.Json;
 
 var subject = "bar.*";
-var options = NatsOpts.Default with { LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()) };
+var options = NatsOpts.Default with
+{
+    LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
+    SerializerRegistry = new NatsJsonSerializerRegistry(),
+};
 
 Print("[CON] Connecting...\n");
 

--- a/sandbox/Example.Core.SubscribeModel/Program.cs
+++ b/sandbox/Example.Core.SubscribeModel/Program.cs
@@ -6,7 +6,7 @@ var subject = "bar.*";
 var options = NatsOpts.Default with
 {
     LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole()),
-    SerializerRegistry = new NatsJsonSerializerRegistry(),
+    SerializerRegistry = NatsJsonSerializerRegistry.Default,
 };
 
 Print("[CON] Connecting...\n");


### PR DESCRIPTION
Currently the example projects `Example.Core.PublishModel`, `Example.Core.SubscribeModel`, `Example.Core.PublishHeaders` and `Example.Core.SubscribeHeaders` are not working because the default serializer can not handle the custom `Bar` type. To make the programs work, we need to provide a serializer for that type. 

To achieve this, i added a project reference to `Nats.Client.Serializers.Json` and configured the `NatsJsonSerializerRegistry` as SerializerRegistry in the mentioned projects.

The same could be achieved by using the AOT ready `NatsJsonContextSerializer` but with we would need to create a custom `JsonSerializerContext` for the `Bar` type in every project. To keep the required code as small as possible, i chose the reflection based serializer.
