### PR TITLE
Object store name check fix

### DIFF
--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -24,8 +24,6 @@ public class NatsObjStore : INatsObjStore
 
     private static readonly NatsHeaders NatsRollupHeaders = new() { { NatsRollup, RollupSubject } };
 
-    private static readonly Regex ValidObjectRegex = new(pattern: @"\A[-/_=\.a-zA-Z0-9]+\z", RegexOptions.Compiled);
-
     private readonly NatsObjContext _objContext;
     private readonly NatsJSContext _context;
     private readonly INatsJSStream _stream;
@@ -657,11 +655,6 @@ public class NatsObjStore : INatsObjStore
         if (string.IsNullOrWhiteSpace(name))
         {
             throw new NatsObjException("Object name can't be empty");
-        }
-
-        if (!ValidObjectRegex.IsMatch(name))
-        {
-            throw new NatsObjException("Object name can only contain alphanumeric characters, dashes, underscores, forward slash, equals sign, and periods");
         }
     }
 }

--- a/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
@@ -100,6 +100,15 @@ public class ObjectStoreTest
             Assert.Equal(chunks, data.Chunks);
             Assert.Equal(size, data.Size);
         }
+
+        // Object name checks
+        {
+            var anyNameIsFine = "any name is fine '~#!$()*/\\,.?<>|{}[]`'\"";
+            await store.PutAsync(anyNameIsFine, new byte[] { 42 }, cancellationToken: cancellationToken);
+            var value = await store.GetBytesAsync(anyNameIsFine, cancellationToken);
+            Assert.Single(value);
+            Assert.Equal(42, value[0]);
+        }
     }
 
     [Fact]

--- a/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
@@ -108,6 +108,17 @@ public class ObjectStoreTest
             var value = await store.GetBytesAsync(anyNameIsFine, cancellationToken);
             Assert.Single(value);
             Assert.Equal(42, value[0]);
+
+            // can't be empty
+            {
+                var exception = await Assert.ThrowsAsync<NatsObjException>(async () => await store.PutAsync(string.Empty, new byte[] { 42 }, cancellationToken: cancellationToken));
+                Assert.Matches("Object name can't be empty", exception.Message);
+            }
+
+            {
+                var exception = await Assert.ThrowsAsync<NatsObjException>(async () => await store.PutAsync(null!, new byte[] { 42 }, cancellationToken: cancellationToken));
+                Assert.Matches("Object name can't be empty", exception.Message);
+            }
         }
     }
 


### PR DESCRIPTION
Since object names are encoded when stores they can be anything as long as not empty.