### PR TITLE
micro-optimizations in ProtocolWriter

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
+        <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);CS1591;SA0001</NoWarn>
         <SignAssembly>true</SignAssembly>

--- a/sandbox/MicroBenchmark/CommandConstantsBench.cs
+++ b/sandbox/MicroBenchmark/CommandConstantsBench.cs
@@ -1,0 +1,150 @@
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+
+namespace MicroBenchmark;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[PlainExporter]
+public class CommandConstantsBench
+{
+    private const ushort NewLineConst = '\r' + ('\n' << 4);
+    private const uint PubSpaceConst = 'P' + ('U' << 8) + ('B' << 16) + (' ' << 24);
+    private const ulong ConnectSpaceConst = 'C' + ('O' << 8) + ('N' << 16) + ('N' << 24) + ((ulong)'E' << 32) + ((ulong)'C' << 40) + ((ulong)'T' << 48) + ((ulong)' ' << 56);
+
+    private static readonly byte[] Bytes = new byte[8];
+    private static readonly ushort NewLineReadonly = BinaryPrimitives.ReadUInt16LittleEndian("\r\n"u8);
+    private static readonly uint PubSpaceReadonly = BinaryPrimitives.ReadUInt32LittleEndian("PUB "u8);
+    private static readonly ulong ConnectSpaceReadonly = BinaryPrimitives.ReadUInt64LittleEndian("CONNECT "u8);
+
+    [Params(1_000_000)]
+    public int Iter { get; set; }
+
+    [Params(2, 4, 8)]
+    public int Size { get; set; }
+
+    private static ReadOnlySpan<byte> NewLine => "\r\n"u8;
+
+    private static ReadOnlySpan<byte> PubSpace => "PUB "u8;
+
+    private static ReadOnlySpan<byte> ConnectSpace => "CONNECT "u8;
+
+    [Benchmark]
+    public void PubCopy()
+    {
+#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+        var src = Size switch
+#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+        {
+            2 => NewLine,
+            4 => PubSpace,
+            8 => ConnectSpace,
+        };
+        var dest = Bytes.AsSpan();
+        for (var i = 0; i < Iter; i++)
+        {
+            PubSpace.CopyTo(dest);
+        }
+    }
+
+    [Benchmark]
+    public void PubSetIndex()
+    {
+        var dest = Bytes.AsSpan();
+        switch (Size)
+        {
+        case 2:
+            for (var i = 0; i < Iter; i++)
+            {
+                dest[0] = (byte)'\r';
+                dest[1] = (byte)'\n';
+            }
+
+            break;
+        case 4:
+            for (var i = 0; i < Iter; i++)
+            {
+                dest[0] = (byte)'P';
+                dest[1] = (byte)'U';
+                dest[2] = (byte)'B';
+                dest[3] = (byte)' ';
+            }
+
+            break;
+        case 8:
+            for (var i = 0; i < Iter; i++)
+            {
+                dest[0] = (byte)'C';
+                dest[1] = (byte)'O';
+                dest[2] = (byte)'N';
+                dest[3] = (byte)'N';
+                dest[4] = (byte)'E';
+                dest[5] = (byte)'C';
+                dest[6] = (byte)'T';
+                dest[7] = (byte)' ';
+            }
+
+            break;
+        }
+    }
+
+    [Benchmark]
+    public void PubBinaryConst()
+    {
+        var dest = Bytes.AsSpan();
+        switch (Size)
+        {
+        case 2:
+            for (var i = 0; i < Iter; i++)
+            {
+                BinaryPrimitives.WriteUInt16LittleEndian(dest, NewLineConst);
+            }
+
+            break;
+        case 4:
+            for (var i = 0; i < Iter; i++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(dest, PubSpaceConst);
+            }
+
+            break;
+        case 8:
+            for (var i = 0; i < Iter; i++)
+            {
+                BinaryPrimitives.WriteUInt64LittleEndian(dest, ConnectSpaceConst);
+            }
+
+            break;
+        }
+    }
+
+    [Benchmark]
+    public void PubBinaryReadonly()
+    {
+        var dest = Bytes.AsSpan();
+        switch (Size)
+        {
+        case 2:
+            for (var i = 0; i < Iter; i++)
+            {
+                BinaryPrimitives.WriteUInt16LittleEndian(dest, NewLineReadonly);
+            }
+
+            break;
+        case 4:
+            for (var i = 0; i < Iter; i++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(dest, PubSpaceReadonly);
+            }
+
+            break;
+        case 8:
+            for (var i = 0; i < Iter; i++)
+            {
+                BinaryPrimitives.WriteUInt64LittleEndian(dest, ConnectSpaceReadonly);
+            }
+
+            break;
+        }
+    }
+}

--- a/sandbox/MicroBenchmark/CommandConstantsBench.cs
+++ b/sandbox/MicroBenchmark/CommandConstantsBench.cs
@@ -32,18 +32,30 @@ public class CommandConstantsBench
     [Benchmark]
     public void PubCopy()
     {
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
-        var src = Size switch
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
-        {
-            2 => NewLine,
-            4 => PubSpace,
-            8 => ConnectSpace,
-        };
         var dest = Bytes.AsSpan();
-        for (var i = 0; i < Iter; i++)
+        switch (Size)
         {
-            PubSpace.CopyTo(dest);
+        case 2:
+            for (var i = 0; i < Iter; i++)
+            {
+                NewLine.CopyTo(dest);
+            }
+
+            break;
+        case 4:
+            for (var i = 0; i < Iter; i++)
+            {
+                PubSpace.CopyTo(dest);
+            }
+
+            break;
+        case 8:
+            for (var i = 0; i < Iter; i++)
+            {
+                ConnectSpace.CopyTo(dest);
+            }
+
+            break;
         }
     }
 

--- a/sandbox/MicroBenchmark/MicroBenchmark.csproj
+++ b/sandbox/MicroBenchmark/MicroBenchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -10,8 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
         <PackageReference Include="StackExchange.Redis" Version="2.5.43" />
         <PackageReference Include="ZLogger" Version="1.6.1" />
         <PackageReference Include="NATS.Client" Version="0.14.5" />

--- a/src/NATS.Client.Core/Commands/ProtocolWriter.cs
+++ b/src/NATS.Client.Core/Commands/ProtocolWriter.cs
@@ -16,8 +16,8 @@ internal sealed class ProtocolWriter
     private const int SubSpaceLength = 4; // "SUB "
     private const int ConnectSpaceLength = 8;  // "CONNECT "
     private const int HpubSpaceLength = 5;  // "HPUB "
-    private const int PingNewLineLength = 6;  // "PING "
-    private const int PongNewLineLength = 6;  // "PONG "
+    private const int PingNewLineLength = 6;  // "PING\r\n"
+    private const int PongNewLineLength = 6;  // "PONG\r\n"
     private const int UnsubSpaceLength = 6;  // "UNSUB "
     private const int UInt16Length = 2;
     private const int UInt64Length = 8;


### PR DESCRIPTION
Resolves #319 

New MicroBenchmark shows benefit in writing UInt 16/32/64.  Maybe because I am on a newer CPU on this box?  :man_shrugging: Looks like it is worth changing though

```

BenchmarkDotNet v0.13.12, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
AMD Ryzen 5 3600, 1 CPU, 12 logical and 6 physical cores
.NET SDK 8.0.101
  [Host]   : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  ShortRun : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
| Method            | Iter    | Size | Mean       | Error     | StdDev  | Allocated |
|------------------ |-------- |----- |-----------:|----------:|--------:|----------:|
| **PubCopy**           | **1000000** | **2**    |   **368.9 μs** | **109.60 μs** | **6.01 μs** |         **-** |
| PubSetIndex       | 1000000 | 2    |   485.2 μs |  59.42 μs | 3.26 μs |         - |
| PubBinaryConst    | 1000000 | 2    |   245.7 μs |  18.84 μs | 1.03 μs |         - |
| PubBinaryReadonly | 1000000 | 2    |   242.5 μs |  56.04 μs | 3.07 μs |         - |
| **PubCopy**           | **1000000** | **4**    |   **483.8 μs** |  **72.14 μs** | **3.95 μs** |         **-** |
| PubSetIndex       | 1000000 | 4    |   969.0 μs |  42.56 μs | 2.33 μs |       1 B |
| PubBinaryConst    | 1000000 | 4    |   247.9 μs |  94.50 μs | 5.18 μs |         - |
| PubBinaryReadonly | 1000000 | 4    |   244.6 μs |  19.72 μs | 1.08 μs |         - |
| **PubCopy**           | **1000000** | **8**    |   **495.1 μs** | **107.94 μs** | **5.92 μs** |         **-** |
| PubSetIndex       | 1000000 | 8    | 1,916.3 μs |   7.41 μs | 0.41 μs |       1 B |
| PubBinaryConst    | 1000000 | 8    |   366.2 μs |  87.33 μs | 4.79 μs |         - |
| PubBinaryReadonly | 1000000 | 8    |   368.6 μs | 128.24 μs | 7.03 μs |         - |


Also added Throw Helper to Protocol Writer as suggested in #320 