### PR TITLE
Nullability review for models

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -149,7 +149,7 @@ dotnet_diagnostic.SA1202.severity = warning  # Elements should be ordered by acc
 dotnet_diagnostic.SA1203.severity = warning  # Constants should appear before fields
 dotnet_diagnostic.SA1204.severity = warning  # Static elements should appear before instance elements
 dotnet_diagnostic.SA1205.severity = warning  # Partial elements should declare access
-dotnet_diagnostic.SA1206.severity = warning  # Declaration keywords should follow order
+dotnet_diagnostic.SA1206.severity = none     # Declaration keywords should follow order
 dotnet_diagnostic.SA1207.severity = warning  # Protected should come before internal
 dotnet_diagnostic.SA1208.severity = warning  # System using directives should be placed before other using directives
 dotnet_diagnostic.SA1209.severity = warning  # Using alias directives should be placed after other using directives
@@ -311,31 +311,31 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+dotnet_naming_symbols.interface.required_modifiers =
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
+dotnet_naming_symbols.types.required_modifiers =
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
+dotnet_naming_symbols.non_field_members.required_modifiers =
 
 # Naming styles
 
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 dotnet_style_coalesce_expression = true:warning
 dotnet_style_null_propagation = true:suggestion

--- a/src/NATS.Client.JetStream/Models/AccountLimits.cs
+++ b/src/NATS.Client.JetStream/Models/AccountLimits.cs
@@ -8,7 +8,7 @@ public record AccountLimits
     [System.Text.Json.Serialization.JsonPropertyName("max_memory")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-1, int.MaxValue)]
-    public int MaxMemory { get; set; } = default!;
+    public int MaxMemory { get; set; }
 
     /// <summary>
     /// The maximum amount of File storage Stream Messages may consume
@@ -16,7 +16,7 @@ public record AccountLimits
     [System.Text.Json.Serialization.JsonPropertyName("max_storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-1, int.MaxValue)]
-    public int MaxStorage { get; set; } = default!;
+    public int MaxStorage { get; set; }
 
     /// <summary>
     /// The maximum number of Streams an account can create
@@ -24,7 +24,7 @@ public record AccountLimits
     [System.Text.Json.Serialization.JsonPropertyName("max_streams")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-1, int.MaxValue)]
-    public int MaxStreams { get; set; } = default!;
+    public int MaxStreams { get; set; }
 
     /// <summary>
     /// The maximum number of Consumer an account can create
@@ -32,21 +32,21 @@ public record AccountLimits
     [System.Text.Json.Serialization.JsonPropertyName("max_consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-1, int.MaxValue)]
-    public int MaxConsumers { get; set; } = default!;
+    public int MaxConsumers { get; set; }
 
     /// <summary>
     /// Indicates if Streams created in this account requires the max_bytes property set
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("max_bytes_required")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool MaxBytesRequired { get; set; } = false;
+    public bool MaxBytesRequired { get; set; }
 
     /// <summary>
     /// The maximum number of outstanding ACKs any consumer may configure
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("max_ack_pending")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public int MaxAckPending { get; set; } = default!;
+    public int MaxAckPending { get; set; }
 
     /// <summary>
     /// The maximum size any single memory stream may be

--- a/src/NATS.Client.JetStream/Models/AccountPurgeResponse.cs
+++ b/src/NATS.Client.JetStream/Models/AccountPurgeResponse.cs
@@ -7,9 +7,9 @@ namespace NATS.Client.JetStream.Models;
 public record AccountPurgeResponse
 {
     /// <summary>
-    /// If the purge operation was succesfully started
+    /// If the purge operation was successfully started
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("initiated")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Initiated { get; set; } = false;
+    public bool Initiated { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/AccountStats.cs
+++ b/src/NATS.Client.JetStream/Models/AccountStats.cs
@@ -8,7 +8,7 @@ public record AccountStats
     [System.Text.Json.Serialization.JsonPropertyName("memory")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Memory { get; set; } = default!;
+    public int Memory { get; set; }
 
     /// <summary>
     /// File Storage being used for Stream Message storage
@@ -16,7 +16,7 @@ public record AccountStats
     [System.Text.Json.Serialization.JsonPropertyName("storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Storage { get; set; } = default!;
+    public int Storage { get; set; }
 
     /// <summary>
     /// Number of active Streams
@@ -24,7 +24,7 @@ public record AccountStats
     [System.Text.Json.Serialization.JsonPropertyName("streams")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Streams { get; set; } = default!;
+    public int Streams { get; set; }
 
     /// <summary>
     /// Number of active Consumers
@@ -32,14 +32,14 @@ public record AccountStats
     [System.Text.Json.Serialization.JsonPropertyName("consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Consumers { get; set; } = default!;
+    public int Consumers { get; set; }
 
     /// <summary>
     /// The JetStream domain this account is in
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("domain")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Domain { get; set; } = default!;
+    public string? Domain { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("limits")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
@@ -48,7 +48,7 @@ public record AccountStats
 
     [System.Text.Json.Serialization.JsonPropertyName("tiers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.IDictionary<string, object> Tiers { get; set; } = default!;
+    public IDictionary<string, object>? Tiers { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("api")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]

--- a/src/NATS.Client.JetStream/Models/ApiError.cs
+++ b/src/NATS.Client.JetStream/Models/ApiError.cs
@@ -8,14 +8,14 @@ public record ApiError
     [System.Text.Json.Serialization.JsonPropertyName("code")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(300, 699)]
-    public int Code { get; set; } = default!;
+    public int Code { get; set; }
 
     /// <summary>
     /// A human friendly description of the error
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("description")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Description { get; set; } = default!;
+    public string? Description { get; set; }
 
     /// <summary>
     /// The NATS error code unique to each kind of error
@@ -23,5 +23,5 @@ public record ApiError
     [System.Text.Json.Serialization.JsonPropertyName("err_code")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, 65535)]
-    public int ErrCode { get; set; } = default!;
+    public int ErrCode { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ApiStats.cs
+++ b/src/NATS.Client.JetStream/Models/ApiStats.cs
@@ -8,7 +8,7 @@ public record ApiStats
     [System.Text.Json.Serialization.JsonPropertyName("total")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Total { get; set; } = default!;
+    public int Total { get; set; }
 
     /// <summary>
     /// API requests that resulted in an error response
@@ -16,5 +16,5 @@ public record ApiStats
     [System.Text.Json.Serialization.JsonPropertyName("errors")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Errors { get; set; } = default!;
+    public int Errors { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ClusterInfo.cs
+++ b/src/NATS.Client.JetStream/Models/ClusterInfo.cs
@@ -7,19 +7,19 @@ public record ClusterInfo
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Name { get; set; } = default!;
+    public string? Name { get; set; }
 
     /// <summary>
     /// The server name of the RAFT leader
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("leader")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Leader { get; set; } = default!;
+    public string? Leader { get; set; }
 
     /// <summary>
     /// The members of the RAFT cluster
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("replicas")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<PeerInfo> Replicas { get; set; } = default!;
+    public ICollection<PeerInfo>? Replicas { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -38,16 +38,16 @@ public record ConsumerConfig
 #if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigDeliverPolicy>))]
 #endif
-    public ConsumerConfigDeliverPolicy DeliverPolicy { get; set; } = default!;
+    public ConsumerConfigDeliverPolicy DeliverPolicy { get; set; } = ConsumerConfigDeliverPolicy.All;
 
     [System.Text.Json.Serialization.JsonPropertyName("opt_start_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public ulong OptStartSeq { get; set; } = default!;
+    public ulong OptStartSeq { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("opt_start_time")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.DateTimeOffset OptStartTime { get; set; } = default!;
+    public DateTimeOffset OptStartTime { get; set; }
 
     /// <summary>
     /// A unique name for a durable consumer
@@ -56,7 +56,7 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
     [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]+$")]
-    public string DurableName { get; set; } = default!;
+    public string? DurableName { get; set; }
 
     /// <summary>
     /// A unique name for a consumer
@@ -65,7 +65,7 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
     [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]+$")]
-    public string Name { get; set; } = default!;
+    public string? Name { get; set; }
 
     /// <summary>
     /// A short description of the purpose of this consumer
@@ -73,12 +73,12 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("description")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.StringLength(4096)]
-    public string Description { get; set; } = default!;
+    public string? Description { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("deliver_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
-    public string DeliverSubject { get; set; } = default!;
+    public string? DeliverSubject { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("ack_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
@@ -102,21 +102,21 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_deliver")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxDeliver { get; set; } = default!;
+    public long MaxDeliver { get; set; }
 
     /// <summary>
     /// Filter the stream by a single subjects
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("filter_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string FilterSubject { get; set; } = default!;
+    public string? FilterSubject { get; set; }
 
     /// <summary>
     /// Filter the stream by multiple subjects
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("filter_subjects")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<string> FilterSubjects { get; set; } = default!;
+    public ICollection<string>? FilterSubjects { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("replay_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
@@ -124,11 +124,11 @@ public record ConsumerConfig
 #if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigReplayPolicy>))]
 #endif
-    public ConsumerConfigReplayPolicy ReplayPolicy { get; set; } = NATS.Client.JetStream.Models.ConsumerConfigReplayPolicy.Instant;
+    public ConsumerConfigReplayPolicy ReplayPolicy { get; set; } = ConsumerConfigReplayPolicy.Instant;
 
     [System.Text.Json.Serialization.JsonPropertyName("sample_freq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string SampleFreq { get; set; } = default!;
+    public string? SampleFreq { get; set; }
 
     /// <summary>
     /// The rate at which messages will be delivered to clients, expressed in bit per second
@@ -136,7 +136,7 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("rate_limit_bps")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long RateLimitBps { get; set; } = default!;
+    public long RateLimitBps { get; set; }
 
     /// <summary>
     /// The maximum number of messages without acknowledgement that can be outstanding, once this limit is reached message delivery will be suspended
@@ -144,7 +144,7 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_ack_pending")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxAckPending { get; set; } = default!;
+    public long MaxAckPending { get; set; }
 
     /// <summary>
     /// If the Consumer is idle for more than this many nano seconds a empty message with Status header 100 will be sent indicating the consumer is still alive
@@ -159,7 +159,7 @@ public record ConsumerConfig
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("flow_control")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool FlowControl { get; set; } = default!;
+    public bool FlowControl { get; set; }
 
     /// <summary>
     /// The number of pulls that can be outstanding on a pull consumer, pulls received after this is reached are ignored
@@ -167,28 +167,28 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_waiting")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxWaiting { get; set; } = default!;
+    public long MaxWaiting { get; set; }
 
     /// <summary>
     /// Creates a special consumer that does not touch the Raft layers, not for general use by clients, internal use only
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("direct")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Direct { get; set; } = false;
+    public bool Direct { get; set; }
 
     /// <summary>
     /// Delivers only the headers of messages in the stream and not the bodies. Additionally adds Nats-Msg-Size header to indicate the size of the removed payload
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("headers_only")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool HeadersOnly { get; set; } = false;
+    public bool HeadersOnly { get; set; }
 
     /// <summary>
     /// The largest batch property that may be specified when doing a pull on a Pull Consumer
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("max_batch")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public int MaxBatch { get; set; } = 0;
+    public int MaxBatch { get; set; }
 
     /// <summary>
     /// The maximum expires value that may be set when doing a pull on a Pull Consumer
@@ -204,7 +204,7 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_bytes")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxBytes { get; set; } = default!;
+    public long MaxBytes { get; set; }
 
     /// <summary>
     /// Duration that instructs the server to cleanup ephemeral consumers that are inactive for that long
@@ -219,7 +219,7 @@ public record ConsumerConfig
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("backoff")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<long> Backoff { get; set; } = default!;
+    public ICollection<long>? Backoff { get; set; }
 
     /// <summary>
     /// When set do not inherit the replica count from the stream but specifically set it to this amount
@@ -227,19 +227,19 @@ public record ConsumerConfig
     [System.Text.Json.Serialization.JsonPropertyName("num_replicas")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long NumReplicas { get; set; } = default!;
+    public long NumReplicas { get; set; }
 
     /// <summary>
     /// Force the consumer state to be kept in memory rather than inherit the setting from the stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("mem_storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool MemStorage { get; set; } = false;
+    public bool MemStorage { get; set; }
 
     /// <summary>
     /// Additional metadata for the Consumer
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("metadata")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.IDictionary<string, string> Metadata { get; set; } = default!;
+    public IDictionary<string, string>? Metadata { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerCreateRequest.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerCreateRequest.cs
@@ -12,12 +12,16 @@ internal record ConsumerCreateRequest
     [System.Text.Json.Serialization.JsonPropertyName("stream_name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string StreamName { get; set; } = default!;
+#else
+    public required string StreamName { get; set; }
+#endif
 
     /// <summary>
     /// The consumer configuration
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("config")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public ConsumerConfig Config { get; set; } = default!;
+    public ConsumerConfig? Config { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerDeleteResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerDeleteResponse.cs
@@ -8,5 +8,5 @@ public record ConsumerDeleteResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = default!;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerGetnextRequest.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerGetnextRequest.cs
@@ -22,7 +22,7 @@ public record ConsumerGetnextRequest
     [System.Text.Json.Serialization.JsonPropertyName("batch")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long Batch { get; set; } = default!;
+    public long Batch { get; set; }
 
     /// <summary>
     /// Sends at most this many bytes to the requestor, limited by consumer configuration max_bytes
@@ -30,14 +30,14 @@ public record ConsumerGetnextRequest
     [System.Text.Json.Serialization.JsonPropertyName("max_bytes")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxBytes { get; set; } = default!;
+    public long MaxBytes { get; set; }
 
     /// <summary>
     /// When true a response with a 404 status header will be returned when no messages are available
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("no_wait")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool NoWait { get; set; } = default!;
+    public bool NoWait { get; set; }
 
     /// <summary>
     /// When not 0 idle heartbeats will be sent on this interval

--- a/src/NATS.Client.JetStream/Models/ConsumerInfo.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerInfo.cs
@@ -8,7 +8,11 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonPropertyName("stream_name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string StreamName { get; set; } = default!;
+#else
+    public required string StreamName { get; set; }
+#endif
 
     /// <summary>
     /// A unique name for the consumer, either machine generated or the durable name
@@ -16,18 +20,22 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonPropertyName("name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// The server time the consumer info was created
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("ts")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.DateTimeOffset Ts { get; set; } = default!;
+    public DateTimeOffset Ts { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("config")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public ConsumerConfig Config { get; set; } = default!;
+    public ConsumerConfig Config { get; set; } = new ConsumerConfig();
 
     /// <summary>
     /// The time the Consumer was created
@@ -35,7 +43,7 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonPropertyName("created")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-    public System.DateTimeOffset Created { get; set; } = default!;
+    public DateTimeOffset Created { get; set; }
 
     /// <summary>
     /// The last message delivered from this Consumer
@@ -59,7 +67,7 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonPropertyName("num_ack_pending")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long NumAckPending { get; set; } = default!;
+    public long NumAckPending { get; set; }
 
     /// <summary>
     /// The number of redeliveries that have been performed
@@ -67,7 +75,7 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonPropertyName("num_redelivered")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long NumRedelivered { get; set; } = default!;
+    public long NumRedelivered { get; set; }
 
     /// <summary>
     /// The number of pull consumers waiting for messages
@@ -75,7 +83,7 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonPropertyName("num_waiting")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long NumWaiting { get; set; } = default!;
+    public long NumWaiting { get; set; }
 
     /// <summary>
     /// The number of messages left unconsumed in this Consumer
@@ -83,16 +91,16 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonPropertyName("num_pending")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long NumPending { get; set; } = default!;
+    public long NumPending { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("cluster")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ClusterInfo Cluster { get; set; } = default!;
+    public ClusterInfo? Cluster { get; set; }
 
     /// <summary>
     /// Indicates if any client is connected and receiving messages from a push consumer
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("push_bound")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool PushBound { get; set; } = default!;
+    public bool PushBound { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerLeaderStepdownResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerLeaderStepdownResponse.cs
@@ -11,5 +11,5 @@ public record ConsumerLeaderStepdownResponse
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = false;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerListResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerListResponse.cs
@@ -12,5 +12,5 @@ public record ConsumerListResponse : IterableResponse
     [System.Text.Json.Serialization.JsonPropertyName("consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
-    public System.Collections.Generic.ICollection<ConsumerInfo> Consumers { get; set; } = new System.Collections.ObjectModel.Collection<ConsumerInfo>();
+    public ICollection<ConsumerInfo> Consumers { get; set; } = new System.Collections.ObjectModel.Collection<ConsumerInfo>();
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerNamesRequest.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerNamesRequest.cs
@@ -11,5 +11,5 @@ public record ConsumerNamesRequest : IterableRequest
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Subject { get; set; } = default!;
+    public string? Subject { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerNamesResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerNamesResponse.cs
@@ -9,5 +9,5 @@ public record ConsumerNamesResponse : IterableResponse
     [System.Text.Json.Serialization.JsonPropertyName("consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
-    public System.Collections.Generic.ICollection<string> Consumers { get; set; } = new System.Collections.ObjectModel.Collection<string>();
+    public ICollection<string> Consumers { get; set; } = new System.Collections.ObjectModel.Collection<string>();
 }

--- a/src/NATS.Client.JetStream/Models/ExternalStreamSource.cs
+++ b/src/NATS.Client.JetStream/Models/ExternalStreamSource.cs
@@ -12,12 +12,16 @@ public record ExternalStreamSource
     [System.Text.Json.Serialization.JsonPropertyName("api")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Api { get; set; } = default!;
+#else
+    public required string Api { get; set; }
+#endif
 
     /// <summary>
     /// The delivery subject to use for the push consumer
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("deliver")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Deliver { get; set; } = default!;
+    public string? Deliver { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/IterableRequest.cs
+++ b/src/NATS.Client.JetStream/Models/IterableRequest.cs
@@ -5,5 +5,5 @@ public record IterableRequest
     [System.Text.Json.Serialization.JsonPropertyName("offset")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Offset { get; set; } = default!;
+    public int Offset { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/IterableResponse.cs
+++ b/src/NATS.Client.JetStream/Models/IterableResponse.cs
@@ -5,15 +5,15 @@ public record IterableResponse
     [System.Text.Json.Serialization.JsonPropertyName("total")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Total { get; set; } = default!;
+    public int Total { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("offset")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Offset { get; set; } = default!;
+    public int Offset { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("limit")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Limit { get; set; } = default!;
+    public int Limit { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/LostStreamData.cs
+++ b/src/NATS.Client.JetStream/Models/LostStreamData.cs
@@ -11,7 +11,7 @@ public record LostStreamData
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("msgs")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<long>? Msgs { get; set; } = default!;
+    public ICollection<long>? Msgs { get; set; }
 
     /// <summary>
     /// The number of bytes that were lost
@@ -19,5 +19,5 @@ public record LostStreamData
     [System.Text.Json.Serialization.JsonPropertyName("bytes")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Bytes { get; set; } = default!;
+    public long Bytes { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/MetaLeaderStepdownRequest.cs
+++ b/src/NATS.Client.JetStream/Models/MetaLeaderStepdownRequest.cs
@@ -8,5 +8,5 @@ public record MetaLeaderStepdownRequest
 {
     [System.Text.Json.Serialization.JsonPropertyName("placement")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public Placement Placement { get; set; } = default!;
+    public Placement? Placement { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/MetaLeaderStepdownResponse.cs
+++ b/src/NATS.Client.JetStream/Models/MetaLeaderStepdownResponse.cs
@@ -11,5 +11,5 @@ public record MetaLeaderStepdownResponse
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = false;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/MetaServerRemoveRequest.cs
+++ b/src/NATS.Client.JetStream/Models/MetaServerRemoveRequest.cs
@@ -11,12 +11,12 @@ public record MetaServerRemoveRequest
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("peer")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Peer { get; set; } = default!;
+    public string? Peer { get; set; }
 
     /// <summary>
     /// Peer ID of the peer to be removed. If specified this is used instead of the server name
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("peer_id")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string PeerId { get; set; } = default!;
+    public string? PeerId { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/MetaServerRemoveResponse.cs
+++ b/src/NATS.Client.JetStream/Models/MetaServerRemoveResponse.cs
@@ -11,5 +11,5 @@ public record MetaServerRemoveResponse
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = false;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/PeerInfo.cs
+++ b/src/NATS.Client.JetStream/Models/PeerInfo.cs
@@ -10,14 +10,18 @@ public record PeerInfo
     [System.Text.Json.Serialization.JsonPropertyName("name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// Indicates if the server is up to date and synchronised
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("current")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Current { get; set; } = false;
+    public bool Current { get; set; }
 
     /// <summary>
     /// Nanoseconds since this peer was last seen
@@ -32,7 +36,7 @@ public record PeerInfo
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("offline")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Offline { get; set; } = false;
+    public bool Offline { get; set; }
 
     /// <summary>
     /// How many uncommitted operations this peer is behind the leader
@@ -40,5 +44,5 @@ public record PeerInfo
     [System.Text.Json.Serialization.JsonPropertyName("lag")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Lag { get; set; } = default!;
+    public int Lag { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/Placement.cs
+++ b/src/NATS.Client.JetStream/Models/Placement.cs
@@ -12,12 +12,16 @@ public record Placement
     [System.Text.Json.Serialization.JsonPropertyName("cluster")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Cluster { get; set; } = default!;
+#else
+    public required string Cluster { get; set; }
+#endif
 
     /// <summary>
     /// Tags required on servers hosting this stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("tags")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<string> Tags { get; set; } = default!;
+    public ICollection<string>? Tags { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/PubAckResponse.cs
+++ b/src/NATS.Client.JetStream/Models/PubAckResponse.cs
@@ -8,7 +8,7 @@ public record PubAckResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("error")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ApiError Error { get; set; } = default!;
+    public ApiError? Error { get; set; }
 
     /// <summary>
     /// The name of the stream that received the message
@@ -16,7 +16,7 @@ public record PubAckResponse
     [System.Text.Json.Serialization.JsonPropertyName("stream")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
-    public string Stream { get; set; } = default!;
+    public string? Stream { get; set; }
 
     /// <summary>
     /// If successful this will be the sequence the message is stored at
@@ -24,19 +24,19 @@ public record PubAckResponse
     [System.Text.Json.Serialization.JsonPropertyName("seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public ulong Seq { get; set; } = default!;
+    public ulong Seq { get; set; }
 
     /// <summary>
     /// Indicates that the message was not stored due to the Nats-Msg-Id header and duplicate tracking
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("duplicate")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Duplicate { get; set; } = false;
+    public bool Duplicate { get; set; }
 
     /// <summary>
     /// If the Stream accepting the message is in a JetStream server configured for a domain this would be that domain
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("domain")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Domain { get; set; } = default!;
+    public string? Domain { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/Republish.cs
+++ b/src/NATS.Client.JetStream/Models/Republish.cs
@@ -12,7 +12,11 @@ public record Republish
     [System.Text.Json.Serialization.JsonPropertyName("src")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Src { get; set; } = default!;
+#else
+    public required string Src { get; set; }
+#endif
 
     /// <summary>
     /// The destination to publish to
@@ -20,12 +24,16 @@ public record Republish
     [System.Text.Json.Serialization.JsonPropertyName("dest")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Dest { get; set; } = default!;
+#else
+    public required string Dest { get; set; }
+#endif
 
     /// <summary>
     /// Only send message headers, no bodies
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("headers_only")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool HeadersOnly { get; set; } = false;
+    public bool HeadersOnly { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/SequenceInfo.cs
+++ b/src/NATS.Client.JetStream/Models/SequenceInfo.cs
@@ -8,7 +8,7 @@ public record SequenceInfo
     [System.Text.Json.Serialization.JsonPropertyName("consumer_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long ConsumerSeq { get; set; } = default!;
+    public long ConsumerSeq { get; set; }
 
     /// <summary>
     /// The sequence number of the Stream
@@ -16,12 +16,12 @@ public record SequenceInfo
     [System.Text.Json.Serialization.JsonPropertyName("stream_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long StreamSeq { get; set; } = default!;
+    public long StreamSeq { get; set; }
 
     /// <summary>
     /// The last time a message was delivered or acknowledged (for ack_floor)
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("last_active")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.DateTimeOffset LastActive { get; set; } = default!;
+    public DateTimeOffset LastActive { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/SequencePair.cs
+++ b/src/NATS.Client.JetStream/Models/SequencePair.cs
@@ -8,7 +8,7 @@ public record SequencePair
     [System.Text.Json.Serialization.JsonPropertyName("consumer_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long ConsumerSeq { get; set; } = default!;
+    public long ConsumerSeq { get; set; }
 
     /// <summary>
     /// The sequence number of the Stream
@@ -16,5 +16,5 @@ public record SequencePair
     [System.Text.Json.Serialization.JsonPropertyName("stream_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long StreamSeq { get; set; } = default!;
+    public long StreamSeq { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StoredMessage.cs
+++ b/src/NATS.Client.JetStream/Models/StoredMessage.cs
@@ -8,7 +8,11 @@ public record StoredMessage
     [System.Text.Json.Serialization.JsonPropertyName("subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
+#if NET6_0
     public string Subject { get; set; } = default!;
+#else
+    public required string Subject { get; set; }
+#endif
 
     /// <summary>
     /// The sequence number of the message in the Stream
@@ -16,7 +20,7 @@ public record StoredMessage
     [System.Text.Json.Serialization.JsonPropertyName("seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public ulong Seq { get; set; } = default!;
+    public ulong Seq { get; set; }
 
     /// <summary>
     /// The base64 encoded payload of the message body
@@ -24,7 +28,7 @@ public record StoredMessage
     [System.Text.Json.Serialization.JsonPropertyName("data")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue)]
-    public string Data { get; set; } = default!;
+    public string? Data { get; set; }
 
     /// <summary>
     /// The time the message was received
@@ -32,12 +36,16 @@ public record StoredMessage
     [System.Text.Json.Serialization.JsonPropertyName("time")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Time { get; set; } = default!;
+#else
+    public required string Time { get; set; }
+#endif
 
     /// <summary>
     /// Base64 encoded headers for the message
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("hdrs")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Hdrs { get; set; } = default!;
+    public string? Hdrs { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamAlternate.cs
+++ b/src/NATS.Client.JetStream/Models/StreamAlternate.cs
@@ -12,7 +12,11 @@ public record StreamAlternate
     [System.Text.Json.Serialization.JsonPropertyName("name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// The name of the cluster holding the stream
@@ -20,12 +24,16 @@ public record StreamAlternate
     [System.Text.Json.Serialization.JsonPropertyName("cluster")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Cluster { get; set; } = default!;
+#else
+    public required string Cluster { get; set; }
+#endif
 
     /// <summary>
     /// The domain holding the string
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("domain")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Domain { get; set; } = default!;
+    public string? Domain { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -21,7 +21,7 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue)]
     [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]*$")]
-    public string Name { get; set; } = default!;
+    public string? Name { get; set; }
 
     /// <summary>
     /// A short description of the purpose of this stream
@@ -29,21 +29,21 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("description")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.StringLength(4096)]
-    public string Description { get; set; } = default!;
+    public string? Description { get; set; }
 
     /// <summary>
     /// A list of subjects to consume, supports wildcards. Must be empty when a mirror is configured. May be empty when sources are configured.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subjects")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<string> Subjects { get; set; } = default!;
+    public ICollection<string>? Subjects { get; set; }
 
     /// <summary>
     /// Subject transform to apply to matching messages
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subject_transform")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public SubjectTransform SubjectTransform { get; set; } = default!;
+    public SubjectTransform? SubjectTransform { get; set; }
 
     /// <summary>
     /// How messages are retained in the Stream, once this is exceeded old messages are removed.
@@ -54,7 +54,7 @@ public record StreamConfig
 #if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigRetention>))]
 #endif
-    public StreamConfigRetention Retention { get; set; } = NATS.Client.JetStream.Models.StreamConfigRetention.Limits;
+    public StreamConfigRetention Retention { get; set; } = StreamConfigRetention.Limits;
 
     /// <summary>
     /// How many Consumers can be defined for a given Stream. -1 for unlimited.
@@ -62,7 +62,7 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxConsumers { get; set; } = default!;
+    public long MaxConsumers { get; set; }
 
     /// <summary>
     /// How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
@@ -70,7 +70,7 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_msgs")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxMsgs { get; set; } = default!;
+    public long MaxMsgs { get; set; }
 
     /// <summary>
     /// For wildcard streams ensure that for every unique subject this many messages are kept - a per subject retention limit
@@ -78,7 +78,7 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_msgs_per_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxMsgsPerSubject { get; set; } = default!;
+    public long MaxMsgsPerSubject { get; set; }
 
     /// <summary>
     /// How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
@@ -86,7 +86,7 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_bytes")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long MaxBytes { get; set; } = default!;
+    public long MaxBytes { get; set; }
 
     /// <summary>
     /// Maximum age of any message in the stream, expressed in nanoseconds. 0 for unlimited.
@@ -102,7 +102,7 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_msg_size")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-2147483648, 2147483647)]
-    public int MaxMsgSize { get; set; } = default!;
+    public int MaxMsgSize { get; set; }
 
     /// <summary>
     /// The storage backend to use for the Stream.
@@ -123,7 +123,7 @@ public record StreamConfig
 #if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigCompression>))]
 #endif
-    public StreamConfigCompression Compression { get; set; } = NATS.Client.JetStream.Models.StreamConfigCompression.None;
+    public StreamConfigCompression Compression { get; set; } = StreamConfigCompression.None;
 
     /// <summary>
     /// How many replicas to keep for each message.
@@ -131,21 +131,21 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("num_replicas")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long NumReplicas { get; set; } = default!;
+    public long NumReplicas { get; set; }
 
     /// <summary>
     /// Disables acknowledging messages that are received by the Stream.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("no_ack")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool NoAck { get; set; } = false;
+    public bool NoAck { get; set; }
 
     /// <summary>
     /// When the Stream is managed by a Stream Template this identifies the template that manages the Stream.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("template_owner")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string TemplateOwner { get; set; } = default!;
+    public string? TemplateOwner { get; set; }
 
     /// <summary>
     /// When a Stream reach it's limits either old messages are deleted or new ones are denied
@@ -170,79 +170,79 @@ public record StreamConfig
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("placement")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public Placement Placement { get; set; } = default!;
+    public Placement? Placement { get; set; }
 
     /// <summary>
     /// Maintains a 1:1 mirror of another stream with name matching this property.  When a mirror is configured subjects and sources must be empty.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("mirror")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public StreamSource Mirror { get; set; } = default!;
+    public StreamSource? Mirror { get; set; }
 
     /// <summary>
     /// List of Stream names to replicate into this Stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("sources")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<StreamSource> Sources { get; set; } = default!;
+    public ICollection<StreamSource>? Sources { get; set; }
 
     /// <summary>
     /// Sealed streams do not allow messages to be deleted via limits or API, sealed streams can not be unsealed via configuration update. Can only be set on already created streams via the Update API
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("sealed")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Sealed { get; set; } = false;
+    public bool Sealed { get; set; }
 
     /// <summary>
     /// Restricts the ability to delete messages from a stream via the API. Cannot be changed once set to true
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("deny_delete")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool DenyDelete { get; set; } = false;
+    public bool DenyDelete { get; set; }
 
     /// <summary>
     /// Restricts the ability to purge messages from a stream via the API. Cannot be change once set to true
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("deny_purge")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool DenyPurge { get; set; } = false;
+    public bool DenyPurge { get; set; }
 
     /// <summary>
     /// Allows the use of the Nats-Rollup header to replace all contents of a stream, or subject in a stream, with a single new message
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("allow_rollup_hdrs")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool AllowRollupHdrs { get; set; } = false;
+    public bool AllowRollupHdrs { get; set; }
 
     /// <summary>
     /// Allow higher performance, direct access to get individual messages
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("allow_direct")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool AllowDirect { get; set; } = false;
+    public bool AllowDirect { get; set; }
 
     /// <summary>
     /// Allow higher performance, direct access for mirrors as well
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("mirror_direct")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool MirrorDirect { get; set; } = false;
+    public bool MirrorDirect { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("republish")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public Republish Republish { get; set; } = default!;
+    public Republish? Republish { get; set; }
 
     /// <summary>
     /// When discard policy is new and the stream is one with max messages per subject set, this will apply the new behavior to every subject. Essentially turning discard new from maximum number of subjects into maximum number of messages in a subject.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("discard_new_per_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool DiscardNewPerSubject { get; set; } = false;
+    public bool DiscardNewPerSubject { get; set; }
 
     /// <summary>
     /// Additional metadata for the Stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("metadata")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.IDictionary<string, string> Metadata { get; set; } = default!;
+    public IDictionary<string, string>? Metadata { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamCreateResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamCreateResponse.cs
@@ -1,7 +1,3 @@
-using System.Text.Json;
-using NATS.Client.Core;
-using NATS.Client.Core.Internal;
-
 namespace NATS.Client.JetStream.Models;
 
 /// <summary>

--- a/src/NATS.Client.JetStream/Models/StreamDeleteResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamDeleteResponse.cs
@@ -8,5 +8,5 @@ public record StreamDeleteResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = default!;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamInfo.cs
+++ b/src/NATS.Client.JetStream/Models/StreamInfo.cs
@@ -24,34 +24,34 @@ public record StreamInfo
     [System.Text.Json.Serialization.JsonPropertyName("created")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-    public System.DateTimeOffset Created { get; set; } = default!;
+    public DateTimeOffset Created { get; set; }
 
     /// <summary>
     /// The server time the stream info was created
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("ts")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.DateTimeOffset Ts { get; set; } = default!;
+    public DateTimeOffset Ts { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("cluster")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ClusterInfo Cluster { get; set; } = default!;
+    public ClusterInfo? Cluster { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("mirror")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public StreamSourceInfo Mirror { get; set; } = default!;
+    public StreamSourceInfo? Mirror { get; set; }
 
     /// <summary>
     /// Streams being sourced into this Stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("sources")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<StreamSourceInfo> Sources { get; set; } = default!;
+    public ICollection<StreamSourceInfo>? Sources { get; set; }
 
     /// <summary>
     /// List of mirrors sorted by priority
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("alternates")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<StreamAlternate> Alternates { get; set; } = default!;
+    public ICollection<StreamAlternate>? Alternates { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamInfoRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamInfoRequest.cs
@@ -11,14 +11,14 @@ public record StreamInfoRequest
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("deleted_details")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool DeletedDetails { get; set; } = default!;
+    public bool DeletedDetails { get; set; }
 
     /// <summary>
     /// When set will return a list of subjects and how many messages they hold for all matching subjects. Filter is a standard NATS subject wildcard pattern.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subjects_filter")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string SubjectsFilter { get; set; } = default!;
+    public string? SubjectsFilter { get; set; }
 
     /// <summary>
     /// Paging offset when retrieving pages of subjet details
@@ -26,5 +26,5 @@ public record StreamInfoRequest
     [System.Text.Json.Serialization.JsonPropertyName("offset")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Offset { get; set; } = default!;
+    public int Offset { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamInfoResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamInfoResponse.cs
@@ -9,15 +9,15 @@ public record StreamInfoResponse : StreamInfo
     [System.Text.Json.Serialization.JsonPropertyName("total")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Total { get; set; } = default!;
+    public int Total { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("offset")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Offset { get; set; } = default!;
+    public int Offset { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("limit")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Limit { get; set; } = default!;
+    public int Limit { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamLeaderStepdownResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamLeaderStepdownResponse.cs
@@ -11,5 +11,5 @@ public record StreamLeaderStepdownResponse
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = false;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamListRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamListRequest.cs
@@ -16,5 +16,5 @@ public record StreamListRequest
     [System.Text.Json.Serialization.JsonPropertyName("offset")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Offset { get; set; } = default!;
+    public int Offset { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamListResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamListResponse.cs
@@ -12,12 +12,12 @@ public record StreamListResponse : IterableResponse
     [System.Text.Json.Serialization.JsonPropertyName("streams")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
-    public System.Collections.Generic.ICollection<StreamInfo> Streams { get; set; } = new System.Collections.ObjectModel.Collection<StreamInfo>();
+    public ICollection<StreamInfo> Streams { get; set; } = new System.Collections.ObjectModel.Collection<StreamInfo>();
 
     /// <summary>
     /// In clustered environments gathering Stream info might time out, this list would be a list of Streams for which information was not obtainable
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("missing")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<string> Missing { get; set; } = default!;
+    public ICollection<string>? Missing { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamMsgDeleteRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamMsgDeleteRequest.cs
@@ -12,12 +12,12 @@ public record StreamMsgDeleteRequest
     [System.Text.Json.Serialization.JsonPropertyName("seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Seq { get; set; } = default!;
+    public long Seq { get; set; }
 
     /// <summary>
     /// Default will securely remove a message and rewrite the data with random data, set this to true to only remove the message
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("no_erase")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool NoErase { get; set; } = default!;
+    public bool NoErase { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamMsgDeleteResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamMsgDeleteResponse.cs
@@ -8,5 +8,5 @@ public record StreamMsgDeleteResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = default!;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamMsgGetRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamMsgGetRequest.cs
@@ -11,19 +11,19 @@ public record StreamMsgGetRequest
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ulong Seq { get; set; } = default!;
+    public ulong Seq { get; set; }
 
     /// <summary>
     /// Retrieves the last message for a given subject, cannot be combined with seq
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("last_by_subj")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string LastBySubj { get; set; } = default!;
+    public string? LastBySubj { get; set; }
 
     /// <summary>
     /// Combined with sequence gets the next message for a subject with the given sequence or higher
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("next_by_subj")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string NextBySubj { get; set; } = default!;
+    public string? NextBySubj { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamMsgGetResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamMsgGetResponse.cs
@@ -9,5 +9,9 @@ public record StreamMsgGetResponse
     [System.Text.Json.Serialization.JsonPropertyName("message")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
-    public StoredMessage Message { get; set; } = new StoredMessage();
+#if NET6_0
+    public StoredMessage Message { get; set; } = default!;
+#else
+    public required StoredMessage Message { get; set; }
+#endif
 }

--- a/src/NATS.Client.JetStream/Models/StreamNamesRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamNamesRequest.cs
@@ -16,5 +16,5 @@ public record StreamNamesRequest
     [System.Text.Json.Serialization.JsonPropertyName("offset")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Offset { get; set; } = default!;
+    public int Offset { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamNamesResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamNamesResponse.cs
@@ -8,5 +8,5 @@ public record StreamNamesResponse : IterableResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("streams")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<string>? Streams { get; set; }
+    public ICollection<string>? Streams { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamPurgeRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamPurgeRequest.cs
@@ -11,7 +11,7 @@ public record StreamPurgeRequest
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("filter")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Filter { get; set; } = default!;
+    public string? Filter { get; set; }
 
     /// <summary>
     /// Purge all messages up to but not including the message with this sequence. Can be combined with subject filter but not the keep option
@@ -19,7 +19,7 @@ public record StreamPurgeRequest
     [System.Text.Json.Serialization.JsonPropertyName("seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Seq { get; set; } = default!;
+    public long Seq { get; set; }
 
     /// <summary>
     /// Ensures this many messages are present after the purge. Can be combined with the subject filter but not the sequence
@@ -27,5 +27,5 @@ public record StreamPurgeRequest
     [System.Text.Json.Serialization.JsonPropertyName("keep")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Keep { get; set; } = default!;
+    public long Keep { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamPurgeResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamPurgeResponse.cs
@@ -8,7 +8,7 @@ public record StreamPurgeResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = default!;
+    public bool Success { get; set; }
 
     /// <summary>
     /// Number of messages purged from the Stream
@@ -16,5 +16,5 @@ public record StreamPurgeResponse
     [System.Text.Json.Serialization.JsonPropertyName("purged")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Purged { get; set; } = default!;
+    public long Purged { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamRemovePeerRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamRemovePeerRequest.cs
@@ -12,5 +12,9 @@ public record StreamRemovePeerRequest
     [System.Text.Json.Serialization.JsonPropertyName("peer")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
+#if NET6_0
     public string Peer { get; set; } = default!;
+#else
+    public required string Peer { get; set; }
+#endif
 }

--- a/src/NATS.Client.JetStream/Models/StreamRemovePeerResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamRemovePeerResponse.cs
@@ -11,5 +11,5 @@ public record StreamRemovePeerResponse
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = false;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamRestoreResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamRestoreResponse.cs
@@ -12,5 +12,9 @@ public record StreamRestoreResponse
     [System.Text.Json.Serialization.JsonPropertyName("deliver_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
+#if NET6_0
     public string DeliverSubject { get; set; } = default!;
+#else
+    public required string DeliverSubject { get; set; }
+#endif
 }

--- a/src/NATS.Client.JetStream/Models/StreamSnapshotRequest.cs
+++ b/src/NATS.Client.JetStream/Models/StreamSnapshotRequest.cs
@@ -12,14 +12,18 @@ public record StreamSnapshotRequest
     [System.Text.Json.Serialization.JsonPropertyName("deliver_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
+#if NET6_0
     public string DeliverSubject { get; set; } = default!;
+#else
+    public required string DeliverSubject { get; set; }
+#endif
 
     /// <summary>
     /// When true consumer states and configurations will not be present in the snapshot
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("no_consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool NoConsumers { get; set; } = default!;
+    public bool NoConsumers { get; set; }
 
     /// <summary>
     /// The size of data chunks to send to deliver_subject
@@ -27,12 +31,12 @@ public record StreamSnapshotRequest
     [System.Text.Json.Serialization.JsonPropertyName("chunk_size")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long ChunkSize { get; set; } = default!;
+    public long ChunkSize { get; set; }
 
     /// <summary>
     /// Check all message's checksums prior to snapshot
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("jsck")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Jsck { get; set; } = false;
+    public bool Jsck { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamSource.cs
+++ b/src/NATS.Client.JetStream/Models/StreamSource.cs
@@ -14,7 +14,11 @@ public record StreamSource
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
     [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]+$")]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// Sequence to start replicating from
@@ -22,30 +26,30 @@ public record StreamSource
     [System.Text.Json.Serialization.JsonPropertyName("opt_start_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long OptStartSeq { get; set; } = default!;
+    public long OptStartSeq { get; set; }
 
     /// <summary>
     /// Time stamp to start replicating from
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("opt_start_time")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.DateTimeOffset OptStartTime { get; set; } = default!;
+    public DateTimeOffset OptStartTime { get; set; }
 
     /// <summary>
     /// Replicate only a subset of messages based on filter
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("filter_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string FilterSubject { get; set; } = default!;
+    public string? FilterSubject { get; set; }
 
     /// <summary>
     /// Subject transforms to apply to matching messages
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subject_transforms")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<SubjectTransform> SubjectTransforms { get; set; } = default!;
+    public ICollection<SubjectTransform>? SubjectTransforms { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("external")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ExternalStreamSource External { get; set; } = default!;
+    public ExternalStreamSource? External { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamSourceInfo.cs
+++ b/src/NATS.Client.JetStream/Models/StreamSourceInfo.cs
@@ -14,21 +14,25 @@ public record StreamSourceInfo
     [System.Text.Json.Serialization.JsonPropertyName("name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// The subject filter to apply to the messages
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("filter_subject")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string FilterSubject { get; set; } = default!;
+    public string? FilterSubject { get; set; }
 
     /// <summary>
     /// The subject transform destination to apply to the messages
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subject_transform_dest")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string SubjectTransformDest { get; set; } = default!;
+    public string? SubjectTransformDest { get; set; }
 
     /// <summary>
     /// How many messages behind the mirror operation is
@@ -36,7 +40,7 @@ public record StreamSourceInfo
     [System.Text.Json.Serialization.JsonPropertyName("lag")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Lag { get; set; } = default!;
+    public long Lag { get; set; }
 
     /// <summary>
     /// When last the mirror had activity, in nanoseconds. Value will be -1 when there has been no activity.
@@ -48,9 +52,9 @@ public record StreamSourceInfo
 
     [System.Text.Json.Serialization.JsonPropertyName("external")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ExternalStreamSource External { get; set; } = default!;
+    public ExternalStreamSource? External { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("error")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ApiError Error { get; set; } = default!;
+    public ApiError? Error { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamState.cs
+++ b/src/NATS.Client.JetStream/Models/StreamState.cs
@@ -8,7 +8,7 @@ public record StreamState
     [System.Text.Json.Serialization.JsonPropertyName("messages")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Messages { get; set; } = default!;
+    public long Messages { get; set; }
 
     /// <summary>
     /// Combined size of all messages in the Stream
@@ -16,7 +16,7 @@ public record StreamState
     [System.Text.Json.Serialization.JsonPropertyName("bytes")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long Bytes { get; set; } = default!;
+    public long Bytes { get; set; }
 
     /// <summary>
     /// Sequence number of the first message in the Stream
@@ -24,14 +24,14 @@ public record StreamState
     [System.Text.Json.Serialization.JsonPropertyName("first_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long FirstSeq { get; set; } = default!;
+    public long FirstSeq { get; set; }
 
     /// <summary>
     /// The timestamp of the first message in the Stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("first_ts")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string FirstTs { get; set; } = default!;
+    public string? FirstTs { get; set; }
 
     /// <summary>
     /// Sequence number of the last message in the Stream
@@ -39,28 +39,28 @@ public record StreamState
     [System.Text.Json.Serialization.JsonPropertyName("last_seq")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0D, 18446744073709552000D)]
-    public long LastSeq { get; set; } = default!;
+    public long LastSeq { get; set; }
 
     /// <summary>
     /// The timestamp of the last message in the Stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("last_ts")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string LastTs { get; set; } = default!;
+    public string? LastTs { get; set; }
 
     /// <summary>
     /// IDs of messages that were deleted using the Message Delete API or Interest based streams removing messages out of order
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("deleted")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<long> Deleted { get; set; } = default!;
+    public ICollection<long>? Deleted { get; set; }
 
     /// <summary>
     /// Subjects and their message counts when a subjects_filter was set
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("subjects")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.IDictionary<string, long>? Subjects { get; set; } = null;
+    public IDictionary<string, long>? Subjects { get; set; }
 
     /// <summary>
     /// The number of unique subjects held in the stream
@@ -68,7 +68,7 @@ public record StreamState
     [System.Text.Json.Serialization.JsonPropertyName("num_subjects")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long NumSubjects { get; set; } = default!;
+    public long NumSubjects { get; set; }
 
     /// <summary>
     /// The number of deleted messages
@@ -76,11 +76,11 @@ public record StreamState
     [System.Text.Json.Serialization.JsonPropertyName("num_deleted")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long NumDeleted { get; set; } = default!;
+    public long NumDeleted { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("lost")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public LostStreamData Lost { get; set; } = default!;
+    public LostStreamData? Lost { get; set; }
 
     /// <summary>
     /// Number of Consumers attached to the Stream
@@ -88,5 +88,5 @@ public record StreamState
     [System.Text.Json.Serialization.JsonPropertyName("consumer_count")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-9223372036854776000D, 9223372036854776000D)]
-    public long ConsumerCount { get; set; } = default!;
+    public long ConsumerCount { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamTemplateConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamTemplateConfig.cs
@@ -14,7 +14,11 @@ public record StreamTemplateConfig
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
     [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]+$")]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// The maximum number of Streams this Template can create, -1 for unlimited.
@@ -22,7 +26,7 @@ public record StreamTemplateConfig
     [System.Text.Json.Serialization.JsonPropertyName("max_streams")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(-2147483648, 2147483647)]
-    public int MaxStreams { get; set; } = default!;
+    public int MaxStreams { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("config")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]

--- a/src/NATS.Client.JetStream/Models/StreamTemplateDeleteResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamTemplateDeleteResponse.cs
@@ -8,5 +8,5 @@ public record StreamTemplateDeleteResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("success")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Success { get; set; } = default!;
+    public bool Success { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamTemplateInfo.cs
+++ b/src/NATS.Client.JetStream/Models/StreamTemplateInfo.cs
@@ -5,7 +5,11 @@ public record StreamTemplateInfo
     [System.Text.Json.Serialization.JsonPropertyName("config")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
-    public StreamTemplateConfig Config { get; set; } = new StreamTemplateConfig();
+#if NET6_0
+    public StreamTemplateConfig Config { get; set; } = default!;
+#else
+    public required StreamTemplateConfig Config { get; set; }
+#endif
 
     /// <summary>
     /// List of Streams managed by this Template
@@ -13,5 +17,5 @@ public record StreamTemplateInfo
     [System.Text.Json.Serialization.JsonPropertyName("streams")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
-    public System.Collections.Generic.ICollection<string> Streams { get; set; } = new System.Collections.ObjectModel.Collection<string>();
+    public ICollection<string> Streams { get; set; } = new System.Collections.ObjectModel.Collection<string>();
 }

--- a/src/NATS.Client.JetStream/Models/StreamTemplateNamesResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamTemplateNamesResponse.cs
@@ -8,5 +8,5 @@ public record StreamTemplateNamesResponse : IterableResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public System.Collections.Generic.ICollection<string> Consumers { get; set; } = default!;
+    public ICollection<string>? Consumers { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/SubjectTransform.cs
+++ b/src/NATS.Client.JetStream/Models/SubjectTransform.cs
@@ -11,7 +11,7 @@ public record SubjectTransform
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("src")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public string Src { get; set; } = default!;
+    public string? Src { get; set; }
 
     /// <summary>
     /// The subject transform destination
@@ -19,5 +19,9 @@ public record SubjectTransform
     [System.Text.Json.Serialization.JsonPropertyName("dest")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+#if NET6_0
     public string Dest { get; set; } = default!;
+#else
+    public required string Dest { get; set; }
+#endif
 }

--- a/src/NATS.Client.JetStream/Models/Tier.cs
+++ b/src/NATS.Client.JetStream/Models/Tier.cs
@@ -8,7 +8,7 @@ public record Tier
     [System.Text.Json.Serialization.JsonPropertyName("memory")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Memory { get; set; } = default!;
+    public int Memory { get; set; }
 
     /// <summary>
     /// File Storage being used for Stream Message storage
@@ -16,7 +16,7 @@ public record Tier
     [System.Text.Json.Serialization.JsonPropertyName("storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Storage { get; set; } = default!;
+    public int Storage { get; set; }
 
     /// <summary>
     /// Number of active Streams
@@ -24,7 +24,7 @@ public record Tier
     [System.Text.Json.Serialization.JsonPropertyName("streams")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Streams { get; set; } = default!;
+    public int Streams { get; set; }
 
     /// <summary>
     /// Number of active Consumers
@@ -32,7 +32,7 @@ public record Tier
     [System.Text.Json.Serialization.JsonPropertyName("consumers")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Consumers { get; set; } = default!;
+    public int Consumers { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("limits")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]

--- a/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
@@ -17,6 +17,7 @@ public partial class NatsJSContext
         StreamConfig config,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(nameof(config.Name));
         var response = await JSRequestResponseAsync<StreamConfig, StreamInfo>(
             subject: $"{Opts.Prefix}.STREAM.CREATE.{config.Name}",
             config,
@@ -118,6 +119,7 @@ public partial class NatsJSContext
         StreamConfig request,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(nameof(request.Name));
         var response = await JSRequestResponseAsync<StreamConfig, StreamUpdateResponse>(
             subject: $"{Opts.Prefix}.STREAM.UPDATE.{request.Name}",
             request: request,

--- a/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
@@ -17,7 +17,7 @@ public partial class NatsJSContext
         StreamConfig config,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(nameof(config.Name));
+        ArgumentNullException.ThrowIfNull(config.Name, nameof(config.Name));
         var response = await JSRequestResponseAsync<StreamConfig, StreamInfo>(
             subject: $"{Opts.Prefix}.STREAM.CREATE.{config.Name}",
             config,
@@ -119,7 +119,7 @@ public partial class NatsJSContext
         StreamConfig request,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(nameof(request.Name));
+        ArgumentNullException.ThrowIfNull(request.Name, nameof(request.Name));
         var response = await JSRequestResponseAsync<StreamConfig, StreamUpdateResponse>(
             subject: $"{Opts.Prefix}.STREAM.UPDATE.{request.Name}",
             request: request,

--- a/src/NATS.Client.JetStream/NatsJSException.cs
+++ b/src/NATS.Client.JetStream/NatsJSException.cs
@@ -83,7 +83,7 @@ public class NatsJSApiException : NatsJSException
     /// </summary>
     /// <param name="error">Error response received from the server.</param>
     public NatsJSApiException(ApiError error)
-        : base(error.Description) =>
+        : base(error.Description ?? string.Empty) =>
         Error = error;
 
     /// <summary>

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -35,7 +35,11 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
 
         // For ordered consumer we start with an empty consumer info object
         // since consumers are created and updated during fetch and consume.
-        Info = new ConsumerInfo();
+        Info = new ConsumerInfo()
+        {
+            Name = string.Empty,
+            StreamName = string.Empty,
+        };
     }
 
     /// <summary>

--- a/src/NATS.Client.JetStream/NatsJSStream.cs
+++ b/src/NATS.Client.JetStream/NatsJSStream.cs
@@ -13,11 +13,15 @@ public class NatsJSStream : INatsJSStream
     private readonly string _name;
     private bool _deleted;
 
+#if DOT_NET_6
+    [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
     internal NatsJSStream(NatsJSContext context, StreamInfo info)
     {
+        ArgumentNullException.ThrowIfNull(nameof(info.Config.Name));
         _context = context;
         Info = info;
-        _name = info.Config.Name;
+        _name = info.Config.Name!;
     }
 
     /// <summary>

--- a/src/NATS.Client.JetStream/NatsJSStream.cs
+++ b/src/NATS.Client.JetStream/NatsJSStream.cs
@@ -18,7 +18,7 @@ public class NatsJSStream : INatsJSStream
 #endif
     internal NatsJSStream(NatsJSContext context, StreamInfo info)
     {
-        ArgumentNullException.ThrowIfNull(nameof(info.Config.Name));
+        ArgumentNullException.ThrowIfNull(info.Config.Name, nameof(info.Config.Name));
         _context = context;
         Info = info;
         _name = info.Config.Name!;

--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -270,7 +270,7 @@ public class NatsKVStore : INatsKVStore
             var bytes = ArrayPool<byte>.Shared.Rent(_context.Connection.Opts.ReaderBufferSize);
             try
             {
-                if (Convert.TryFromBase64String(response.Message.Data, bytes, out var written))
+                if (response.Message.Data != null && Convert.TryFromBase64String(response.Message.Data, bytes, out var written))
                 {
                     var buffer = new ReadOnlySequence<byte>(bytes.AsMemory(0, written));
                     data = serializer.Deserialize(buffer);

--- a/src/NATS.Client.ObjectStore/Models/ObjectMetadata.cs
+++ b/src/NATS.Client.ObjectStore/Models/ObjectMetadata.cs
@@ -8,80 +8,84 @@ public record ObjectMetadata
     /// Object name
     /// </summary>
     [JsonPropertyName("name")]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// Object description
     /// </summary>
     [JsonPropertyName("description")]
-    public string Description { get; set; } = default!;
+    public string? Description { get; set; }
 
     /// <summary>
     /// Bucket name
     /// </summary>
     [JsonPropertyName("bucket")]
-    public string Bucket { get; set; } = default!;
+    public string? Bucket { get; set; }
 
     /// <summary>
     /// Object NUID
     /// </summary>
     [JsonPropertyName("nuid")]
-    public string Nuid { get; set; } = default!;
+    public string? Nuid { get; set; }
 
     /// <summary>
     /// Max chunk size
     /// </summary>
     [JsonPropertyName("size")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Size { get; set; } = default!;
+    public int Size { get; set; }
 
     /// <summary>
     /// Modified timestamp
     /// </summary>
     [JsonPropertyName("mtime")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public DateTimeOffset MTime { get; set; } = default!;
+    public DateTimeOffset MTime { get; set; }
 
     /// <summary>
     /// Number of chunks
     /// </summary>
     [JsonPropertyName("chunks")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Chunks { get; set; } = default!;
+    public int Chunks { get; set; }
 
     /// <summary>
     /// Object digest
     /// </summary>
     [JsonPropertyName("digest")]
-    public string Digest { get; set; } = default!;
+    public string? Digest { get; set; }
 
     /// <summary>
     /// Object metadata
     /// </summary>
     [JsonPropertyName("metadata")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public Dictionary<string, string> Metadata { get; set; } = default!;
+    public Dictionary<string, string>? Metadata { get; set; }
 
     /// <summary>
     /// Object metadata
     /// </summary>
     [JsonPropertyName("headers")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public Dictionary<string, string> Headers { get; set; } = default!;
+    public Dictionary<string, string>? Headers { get; set; }
 
     /// <summary>
     /// Object deleted
     /// </summary>
     [JsonPropertyName("deleted")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Deleted { get; set; } = default!;
+    public bool Deleted { get; set; }
 
     /// <summary>
     /// Object options
     /// </summary>
     [JsonPropertyName("options")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public MetaDataOptions? Options { get; set; } = default!;
+    public MetaDataOptions? Options { get; set; }
 }
 
 public record MetaDataOptions
@@ -91,14 +95,14 @@ public record MetaDataOptions
     /// </summary>
     [JsonPropertyName("link")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public NatsObjLink? Link { get; set; } = default!;
+    public NatsObjLink? Link { get; set; }
 
     /// <summary>
     /// Max chunk size
     /// </summary>
     [JsonPropertyName("max_chunk_size")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int? MaxChunkSize { get; set; } = default!;
+    public int? MaxChunkSize { get; set; }
 }
 
 public record NatsObjLink
@@ -107,13 +111,21 @@ public record NatsObjLink
     /// Link name
     /// </summary>
     [JsonPropertyName("name")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+#if NET6_0
     public string Name { get; set; } = default!;
+#else
+    public required string Name { get; set; }
+#endif
 
     /// <summary>
     /// Bucket name
     /// </summary>
     [JsonPropertyName("bucket")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+#if NET6_0
     public string Bucket { get; set; } = default!;
+#else
+    public required string Bucket { get; set; }
+#endif
 }

--- a/tests/NATS.Client.JetStream.Tests/PublishTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PublishTest.cs
@@ -74,9 +74,9 @@ public class PublishTest
                 data: 2,
                 opts: new NatsJSPubOpts { ExpectedStream = "non-existent-stream" },
                 cancellationToken: cts.Token);
-            Assert.Equal(400, ack2.Error.Code);
-            Assert.Equal(10060, ack2.Error.ErrCode);
-            Assert.Equal("expected stream does not match", ack2.Error.Description);
+            Assert.Equal(400, ack2.Error?.Code);
+            Assert.Equal(10060, ack2.Error?.ErrCode);
+            Assert.Equal("expected stream does not match", ack2.Error?.Description);
         }
 
         // ExpectedLastSequence
@@ -99,9 +99,9 @@ public class PublishTest
                 data: 3,
                 opts: new NatsJSPubOpts { ExpectedLastSequence = ack1.Seq },
                 cancellationToken: cts.Token);
-            Assert.Equal(400, ack3.Error.Code);
-            Assert.Equal(10071, ack3.Error.ErrCode);
-            Assert.Matches(@"wrong last sequence: \d+", ack3.Error.Description);
+            Assert.Equal(400, ack3.Error?.Code);
+            Assert.Equal(10071, ack3.Error?.ErrCode);
+            Assert.Matches(@"wrong last sequence: \d+", ack3.Error?.Description);
         }
 
         // ExpectedLastSubjectSequence
@@ -124,9 +124,9 @@ public class PublishTest
                 data: 3,
                 opts: new NatsJSPubOpts { ExpectedLastSubjectSequence = ack1.Seq },
                 cancellationToken: cts.Token);
-            Assert.Equal(400, ack3.Error.Code);
-            Assert.Equal(10071, ack3.Error.ErrCode);
-            Assert.Matches(@"wrong last sequence: \d+", ack3.Error.Description);
+            Assert.Equal(400, ack3.Error?.Code);
+            Assert.Equal(10071, ack3.Error?.ErrCode);
+            Assert.Matches(@"wrong last sequence: \d+", ack3.Error?.Description);
         }
 
         // ExpectedLastMsgId
@@ -150,9 +150,9 @@ public class PublishTest
                 data: 3,
                 opts: new NatsJSPubOpts { MsgId = "ExpectedLastMsgId-3", ExpectedLastMsgId = "unexpected-msg-id" },
                 cancellationToken: cts.Token);
-            Assert.Equal(400, ack3.Error.Code);
-            Assert.Equal(10070, ack3.Error.ErrCode);
-            Assert.Equal("wrong last msg ID: ExpectedLastMsgId-2", ack3.Error.Description);
+            Assert.Equal(400, ack3.Error?.Code);
+            Assert.Equal(10070, ack3.Error?.ErrCode);
+            Assert.Equal("wrong last msg ID: ExpectedLastMsgId-2", ack3.Error?.Description);
         }
     }
 

--- a/tests/NATS.Client.JetStream.Tests/TimeSpanJsonTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/TimeSpanJsonTests.cs
@@ -137,7 +137,7 @@ public class TimeSpanJsonTests
         var serializer = NatsJSJsonSerializer<PeerInfo>.Default;
 
         var bw = new NatsBufferWriter<byte>();
-        serializer.Serialize(bw, new PeerInfo { Active = time });
+        serializer.Serialize(bw, new PeerInfo { Name = "test", Active = time });
 
         var json = Encoding.UTF8.GetString(bw.WrittenSpan);
         Assert.Matches(expected, json);
@@ -197,7 +197,7 @@ public class TimeSpanJsonTests
         var serializer = NatsJSJsonSerializer<StreamSourceInfo>.Default;
 
         var bw = new NatsBufferWriter<byte>();
-        serializer.Serialize(bw, new StreamSourceInfo { Active = time });
+        serializer.Serialize(bw, new StreamSourceInfo { Name = "test", Active = time });
 
         var json = Encoding.UTF8.GetString(bw.WrittenSpan);
         Assert.Matches(expected, json);

--- a/tests/Nats.Client.Compat/ObjectStoreCompat.cs
+++ b/tests/Nats.Client.Compat/ObjectStoreCompat.cs
@@ -145,7 +145,8 @@ public class ObjectStoreCompat
         var list = new List<string>();
         await foreach (var info in store.WatchAsync())
         {
-            list.Add(info.Digest);
+            if (info.Digest is not null)
+                list.Add(info.Digest);
             if (list.Count == 2)
                 break;
         }


### PR DESCRIPTION
Made optional reference properties nullable unless a meaningful default value is  provided. 

Removed redundant default assignments and cleaned up some code generated namespace prefixes.

Marked required properties (derived from attribute annotations and code inspection). Any use of "required" is in a conditional code block, as the JSON source generator for 6.0 doesn't understand the keyword and thus produces invalid code. Maybe this can be solved by using the code generated for 8.0 also for the 6.0 build.

Adjusted code in a few places where required properties had to be set and some nullable properties had to be checked before use.
 
Excluded SC1206 warnings from editorconfig (couldn't manage to use the required keywork with it enabled). This is likely fixable but apparently beyond my skills :)

As the model signatures have changed, this PR is a breaking change.