### PR TITLE
 pipe reader: don't mark commands as consumed until pending=0 

### DIFF
--- a/src/NATS.Client.Core/Commands/ProtocolWriter.cs
+++ b/src/NATS.Client.Core/Commands/ProtocolWriter.cs
@@ -91,12 +91,12 @@ internal sealed class ProtocolWriter
         int ctrlLen;
         if (headers == null)
         {
-            // 'PUB '   + subject                                +' '+ payload len        +'\r\n'
+            // 'PUB '   + subject                                             +' '+ payload len        +'\r\n'
             ctrlLen = PubSpaceLength + _subjectEncoding.GetByteCount(subject) + 1 + MaxIntStringLength + NewLineLength;
         }
         else
         {
-            // 'HPUB '  + subject                                +' '+ header len         +' '+ payload len        +'\r\n'
+            // 'HPUB '  + subject                                              +' '+ header len         +' '+ payload len        +'\r\n'
             ctrlLen = HpubSpaceLength + _subjectEncoding.GetByteCount(subject) + 1 + MaxIntStringLength + 1 + MaxIntStringLength + NewLineLength;
         }
 

--- a/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
+++ b/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace NATS.Client.TestUtilities;
+
+public class InMemoryTestLoggerFactory(LogLevel level) : ILoggerFactory
+{
+    private readonly List<LogMessage> _messages = new();
+
+    public IReadOnlyList<LogMessage> Logs
+    {
+        get
+        {
+            lock (_messages)
+                return _messages.ToList();
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName) => new TestLogger(categoryName, level, this);
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private void Log(string categoryName, LogLevel logLevel, EventId eventId, Exception? exception, string message)
+    {
+        lock (_messages)
+            _messages.Add(new LogMessage(categoryName, logLevel, eventId, exception, message));
+    }
+
+    public record LogMessage(string Category, LogLevel LogLevel, EventId EventId, Exception? Exception, string Message);
+
+    private class TestLogger(string categoryName, LogLevel level, InMemoryTestLoggerFactory logger) : ILogger
+    {
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel >= level)
+                logger.Log(categoryName, logLevel, eventId, exception, formatter(state, exception));
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= level;
+
+        public IDisposable BeginScope<TState>(TState state) => new NullDisposable();
+
+        private class NullDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
+++ b/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace NATS.Client.TestUtilities;
 


### PR DESCRIPTION
Includes test from #346 (e90d588d9c2732ffd64729d177bdfe93646e9505) - thanks for recreating @mtmk 

Previously, commands that were partially trimmed but not sent had marked their data from the pipe reader as Consumed.  On a Reconnect, the same amount of data would get Consumed again.

Refactors the Pipe Reader to only mark data as consumed once an entire command has been processed (pending == 0)

Also adds a bunch of comments to help explain the flow