### PR TITLE
Fix unnecessary error log on dispose

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -640,6 +640,10 @@ public partial class NatsConnection : INatsConnection
                 }
             }
         }
+        catch (OperationCanceledException)
+        {
+            // Ignore, we're disposing the connection
+        }
         catch (Exception ex)
         {
             _logger.LogError(NatsLogEvents.Connection, ex, "Error occured when publishing events");


### PR DESCRIPTION
Ignore operation cancel error in event handling loop since it'd be cancelled on connection dispose.
This is causing unclean server shutdown in some cases.

original thread https://natsio.slack.com/archives/C1V81FKU6/p1706128132853999

cc @mnmr 