### PR TITLE
Ping command as value task source

### DIFF
--- a/sandbox/MicroBenchmark/PingBench.cs
+++ b/sandbox/MicroBenchmark/PingBench.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+using NATS.Client.Core;
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+namespace MicroBenchmark;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[PlainExporter]
+public class PingBench
+{
+    private NatsConnection _nats;
+
+    [Params(64, 512, 1024)]
+    public int Iter { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _nats = new NatsConnection();
+
+    [Benchmark]
+    public async ValueTask<TimeSpan> PingAsync()
+    {
+        var total = TimeSpan.Zero;
+
+        for (var i = 0; i < Iter; i++)
+        {
+            total += await _nats.PingAsync();
+        }
+
+        return total;
+    }
+}

--- a/src/NATS.Client.Core/Commands/PingCommand.cs
+++ b/src/NATS.Client.Core/Commands/PingCommand.cs
@@ -1,12 +1,56 @@
+using System.Threading.Tasks.Sources;
+using NATS.Client.Core.Internal;
+
 namespace NATS.Client.Core.Commands;
 
-internal struct PingCommand
+internal class PingCommand : IValueTaskSource<TimeSpan>, IObjectPoolNode<PingCommand>
 {
-    public PingCommand()
+    private readonly ObjectPool? _pool;
+    private DateTimeOffset _start;
+    private ManualResetValueTaskSourceCore<TimeSpan> _core;
+    private PingCommand? _next;
+
+    public PingCommand(ObjectPool? pool)
     {
+        _pool = pool;
+        _core = new ManualResetValueTaskSourceCore<TimeSpan>
+        {
+            RunContinuationsAsynchronously = true,
+        };
+        _start = DateTimeOffset.MinValue;
     }
 
-    public DateTimeOffset WriteTime { get; } = DateTimeOffset.UtcNow;
+    public ref PingCommand? NextNode => ref _next;
 
-    public TaskCompletionSource<TimeSpan> TaskCompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public void Start() => _start = DateTimeOffset.UtcNow;
+
+    public void SetResult() => _core.SetResult(DateTimeOffset.UtcNow - _start);
+
+    public void SetCanceled() => _core.SetException(new OperationCanceledException());
+
+    public void Reset()
+    {
+        _start = DateTimeOffset.MinValue;
+        _core.Reset();
+    }
+
+    public ValueTask<TimeSpan> RunAsync() => new(this, _core.Version);
+
+    public TimeSpan GetResult(short token)
+    {
+        var result = _core.GetResult(token);
+
+        if (_pool is not null)
+        {
+            Reset();
+            _pool.Return(this);
+        }
+
+        return result;
+    }
+
+    public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
+
+    public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        => _core.OnCompleted(continuation, state, token, flags);
 }

--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -52,7 +52,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
             await _readLoop.ConfigureAwait(false); // wait for drain buffer.
             foreach (var item in _pingCommands)
             {
-                item.TaskCompletionSource.SetCanceled();
+                item.SetCanceled();
             }
 
             _waitForInfoSignal.TrySetCanceled();
@@ -329,7 +329,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
 
             if (_pingCommands.TryDequeue(out var pingCommand))
             {
-                pingCommand.TaskCompletionSource.SetResult(DateTimeOffset.UtcNow - pingCommand.WriteTime);
+                pingCommand.SetResult();
             }
 
             if (length < PongSize)

--- a/src/NATS.Client.Core/NatsConnection.Ping.cs
+++ b/src/NATS.Client.Core/NatsConnection.Ping.cs
@@ -12,9 +12,17 @@ public partial class NatsConnection
             await ConnectAsync().AsTask().WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var pingCommand = new PingCommand();
+        PingCommand pingCommand;
+        if (!_pool.TryRent(out pingCommand!))
+        {
+            pingCommand = new PingCommand(_pool);
+        }
+
+        pingCommand.Start();
+
         await CommandWriter.PingAsync(pingCommand, cancellationToken).ConfigureAwait(false);
-        return await pingCommand.TaskCompletionSource.Task.ConfigureAwait(false);
+
+        return await pingCommand.RunAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -27,6 +35,6 @@ public partial class NatsConnection
     /// <returns><see cref="ValueTask"/> representing the asynchronous operation</returns>
     private ValueTask PingOnlyAsync(CancellationToken cancellationToken = default) =>
         ConnectionState == NatsConnectionState.Open
-            ? CommandWriter.PingAsync(new PingCommand(), cancellationToken)
+            ? CommandWriter.PingAsync(new PingCommand(_pool), cancellationToken)
             : ValueTask.CompletedTask;
 }

--- a/src/NATS.Client.Core/NatsConnection.Ping.cs
+++ b/src/NATS.Client.Core/NatsConnection.Ping.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using NATS.Client.Core.Commands;
 
 namespace NATS.Client.Core;
@@ -5,6 +6,7 @@ namespace NATS.Client.Core;
 public partial class NatsConnection
 {
     /// <inheritdoc />
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     public async ValueTask<TimeSpan> PingAsync(CancellationToken cancellationToken = default)
     {
         if (ConnectionState != NatsConnectionState.Open)

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -432,7 +432,7 @@ public partial class NatsConnection : INatsConnection
             {
                 // add CONNECT and PING command to priority lane
                 await priorityCommandWriter.CommandWriter.ConnectAsync(_clientOpts, CancellationToken.None).ConfigureAwait(false);
-                await priorityCommandWriter.CommandWriter.PingAsync(new PingCommand(), CancellationToken.None).ConfigureAwait(false);
+                await priorityCommandWriter.CommandWriter.PingAsync(new PingCommand(_pool), CancellationToken.None).ConfigureAwait(false);
 
                 Task? reconnectTask = null;
                 if (reconnect)
@@ -768,7 +768,7 @@ public partial class NatsConnection : INatsConnection
         }
 
         // Can not add PING, set fail.
-        pingCommand.TaskCompletionSource.SetCanceled();
+        pingCommand.SetCanceled();
     }
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
main:
| Method       | Iter | Mean     | Error     | StdDev  | Allocated |
|------------- |----- |---------:|----------:|--------:|----------:|
| PublishAsync | 64   | 165.9 us |  39.41 us | 2.16 us |     488 B |
| PublishAsync | 512  | 375.1 us |  81.65 us | 4.48 us |     488 B |
| PublishAsync | 1024 | 607.0 us | 152.22 us | 8.34 us |     488 B |

| Method    | Iter | Mean       | Error      | StdDev    | Allocated |
|---------- |----- |-----------:|-----------:|----------:|----------:|
| PingAsync | 64   |   6.915 ms |  0.6316 ms | 0.0346 ms |   17.7 KB |
| PingAsync | 512  |  55.737 ms | 33.2913 ms | 1.8248 ms | 140.31 KB |
| PingAsync | 1024 | 114.085 ms | 30.5851 ms | 1.6765 ms |  280.4 KB |

This PR:
| Method       | Iter | Mean     | Error    | StdDev  | Allocated |
|------------- |----- |---------:|---------:|--------:|----------:|
| PublishAsync | 64   | 166.8 us | 48.84 us | 2.68 us |     391 B |
| PublishAsync | 512  | 375.6 us | 30.69 us | 1.68 us |     408 B |
| PublishAsync | 1024 | 612.3 us | 33.39 us | 1.83 us |     437 B |

| Method    | Iter | Mean       | Error     | StdDev    | Allocated |
|---------- |----- |-----------:|----------:|----------:|----------:|
| PingAsync | 64   |   6.998 ms |  1.383 ms | 0.0758 ms |    1006 B |
| PingAsync | 512  |  58.303 ms | 11.769 ms | 0.6451 ms |    4083 B |
| PingAsync | 1024 | 114.295 ms | 30.954 ms | 1.6967 ms |   12946 B |