### PR TITLE
Text matrix CI server versions

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: '2.9'
-          - branch: '2.10'
+          - branch: 'v2.9.22'
+          - branch: 'v2.10.9'
           - branch: 'main'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: release/v2.9.23
-          - branch: latest
+          - branch: 2.9
+          - branch: 2.10
           - branch: main
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 2.9
-          - branch: 2.10
-          - branch: main
+          - branch: '2.9'
+          - branch: '2.10'
+          - branch: 'main'
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 2.9
-          - branch: 2.10
-          - branch: main
+          - branch: '2.9'
+          - branch: '2.10'
+          - branch: 'main'
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -86,9 +86,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 2.9
-          - branch: 2.10
-          - branch: main
+          - branch: '2.9'
+          - branch: '2.10'
+          - branch: 'main'
     runs-on: windows-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: '2.9'
-          - branch: '2.10'
+          - branch: 'v2.9.22'
+          - branch: 'v2.10.9'
           - branch: 'main'
     runs-on: ubuntu-latest
     env:
@@ -86,8 +86,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: '2.9'
-          - branch: '2.10'
+          - branch: 'v2.9.22'
+          - branch: 'v2.10.9'
           - branch: 'main'
     runs-on: windows-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: release/v2.9.23
-          - branch: latest
+          - branch: 2.9
+          - branch: 2.10
           - branch: main
     runs-on: ubuntu-latest
     env:
@@ -86,8 +86,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: release/v2.9.23
-          - branch: latest
+          - branch: 2.9
+          - branch: 2.10
           - branch: main
     runs-on: windows-latest
     env:


### PR DESCRIPTION
When using binaries.nats.dev, branch names `latest` and `main` were both picking up the same development version. Also release now picks the latest 2.9.x

Now we test for: 2.9, 2.10 and main

**Edit:** I was wrong, this isn't working. We still need to find a way to test 2.10.x latest. `main` and `latest` tags are giving us the same binary.

**Edit2:**: We'll use the exact versions until above tags are supported by binaries service.