### PR TITLE
Test that reconnect doesn't drop partially sent messages

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -133,6 +133,9 @@ public partial class NatsConnection : INatsConnection
 
     internal ObjectPool ObjectPool => _pool;
 
+    // only used for internal testing
+    internal ISocketConnection TestSocket => _socket;
+
     /// <summary>
     /// Connect socket and write CONNECT command to nats server.
     /// </summary>


### PR DESCRIPTION
Add a test that checks that client-side reconnects don't drop partially sent messages out of the send buffer