### PR TITLE
Prevent KeyValueStore error when MaxAge is set below the default DuplicateWindow value

### DIFF
--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -108,8 +108,12 @@ public class NatsKVContext : INatsKVContext
             // MirrorDirect =
             // Mirror =
             Retention = StreamConfigRetention.Limits, // from ADR-8
-            DuplicateWindow = TimeSpan.FromMinutes(2), // 120_000_000_000ns, from ADR-8
+            DuplicateWindow = config.MaxAge != default ? config.MaxAge : TimeSpan.FromMinutes(2), // 120_000_000_000ns, from ADR-8
         };
+
+        // https://github.com/nats-io/nats.go/blob/98430acd80423b776149f29d625d158f490ac3c5/jetstream/kv.go#L334-L342
+        if (streamConfig.MaxAge > TimeSpan.Zero && streamConfig.MaxAge < streamConfig.DuplicateWindow)
+            streamConfig.DuplicateWindow = streamConfig.MaxAge;
 
         var stream = await _context.CreateStreamAsync(streamConfig, cancellationToken);
 


### PR DESCRIPTION
When setting a MaxAge less than the default DuplicateWindow value, you receive the following error. This PR fixes this.

```
NATS.Client.JetStream.NatsJSApiException: duplicates window can not be larger then max age
   at NATS.Client.JetStream.Internal.NatsJSResponse`1.EnsureSuccess() in C:\SourceControl\Random\nats.net.v2\src\NATS.Client.JetStream\Internal\NatsJSResponse.cs:line 27
   at NATS.Client.JetStream.NatsJSContext.JSRequestResponseAsync[TRequest,TResponse](String subject, TRequest request, CancellationToken cancellationToken) in C:\SourceControl\Random\nats.net.v2\src\NATS.Client.JetStream\NatsJSContext.cs:line 185
   at NATS.Client.JetStream.NatsJSContext.CreateStreamAsync(StreamConfig config, CancellationToken cancellationToken) in C:\SourceControl\Random\nats.net.v2\src\NATS.Client.JetStream\NatsJSContext.Streams.cs:line 21
   at NATS.Client.KeyValueStore.NatsKVContext.CreateStoreAsync(NatsKVConfig config, CancellationToken cancellationToken) in C:\SourceControl\Random\nats.net.v2\src\NATS.Client.KeyValueStore\NatsKVContext.cs:line 115
   at Program.<Main>$(String[] args) in C:\SourceControl\Random\nats.net.v2\sandbox\Example.KeyValueStore.Watcher\Program.cs:line 18
   at Program.<Main>(String[] args)
```

Modified `Example.KeyValueStore.Watcher` code to reproduce:
```cs
var nats = new NatsConnection();

var js = new NatsJSContext(nats);
var kv = new NatsKVContext(js);

var config = new NatsKVConfig("e1")
{
    MaxAge = TimeSpan.FromSeconds(30),
};

var store = await kv.CreateStoreAsync(config);

await foreach (var entry in store.WatchAsync<int>())
{
    Console.WriteLine($"[RCV] {entry}");
}
```