### PR TITLE
Added deliver_group to consumer config

### DIFF
--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -80,6 +80,11 @@ public record ConsumerConfig
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
     public string? DeliverSubject { get; set; }
 
+    [System.Text.Json.Serialization.JsonPropertyName("deliver_group")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
+    public string? DeliverGroup { get; set; }
+
     [System.Text.Json.Serialization.JsonPropertyName("ack_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]

--- a/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
@@ -1,0 +1,39 @@
+using NATS.Client.Core.Tests;
+using NATS.Client.JetStream.Models;
+
+namespace NATS.Client.JetStream.Tests;
+
+public class ConsumerSetupTest
+{
+    [Fact]
+    public async Task Create_push_consumer()
+    {
+        await using var server = NatsServer.StartJS();
+        await using var nats = server.CreateClientConnection();
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+
+        await js.CreateOrUpdateConsumerAsync(
+            stream: "s1",
+            config: new ConsumerConfig
+            {
+                Name = "c1",
+                DeliverSubject = "i1",
+                DeliverGroup = "q1",
+            },
+            cancellationToken: cts.Token);
+
+        var consumer = await js.GetConsumerAsync("s1", "c1", cts.Token);
+
+        var info = consumer.Info;
+        Assert.Equal("s1", info.StreamName);
+
+        var config = info.Config;
+        Assert.Equal("c1", config.Name);
+        Assert.Equal("i1", config.DeliverSubject);
+        Assert.Equal("q1", config.DeliverGroup);
+    }
+}


### PR DESCRIPTION
Added the missing property for `deliver_group`.

Note: ConsumerConfig was generated from this schema I believe, which doesn't have deliver_group defined https://github.com/nats-io/jsm.go/blob/main/schemas/jetstream/api/v1/consumer_create_request.json#L140 