### PR TITLE
Expose Headers on NatsSvcMsg

### DIFF
--- a/src/NATS.Client.Services/NatsSvcMsg.cs
+++ b/src/NATS.Client.Services/NatsSvcMsg.cs
@@ -48,6 +48,11 @@ public readonly struct NatsSvcMsg<T>
     public string? ReplyTo => _msg.ReplyTo;
 
     /// <summary>
+    /// Pass additional information using name-value pairs.
+    /// </summary>
+    public NatsHeaders? Headers => _msg.Headers;
+
+    /// <summary>
     /// Send a reply with an empty message body.
     /// </summary>
     /// <param name="headers">Optional message headers.</param>

--- a/tests/NATS.Client.Services.Tests/ServicesTests.cs
+++ b/tests/NATS.Client.Services.Tests/ServicesTests.cs
@@ -196,7 +196,10 @@ public class ServicesTests
         await using var s2 = await svc.AddServiceAsync(
             new NatsSvcConfig("s2", "2.0.0")
             {
-                Description = "es-two", QueueGroup = "q2", Metadata = new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" }, }, StatsHandler = ep => JsonNode.Parse($"{{\"stat-k1\":\"stat-v1\",\"stat-k2\":\"stat-v2\",\"ep_name\": \"{ep.Name}\"}}")!,
+                Description = "es-two",
+                QueueGroup = "q2",
+                Metadata = new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" }, },
+                StatsHandler = ep => JsonNode.Parse($"{{\"stat-k1\":\"stat-v1\",\"stat-k2\":\"stat-v2\",\"ep_name\": \"{ep.Name}\"}}")!,
             },
             cancellationToken: cancellationToken);
 


### PR DESCRIPTION
Thi pr adds the following

* Exposes Heades on NatsSvcMsg (forwarded from the underlying NastMsg)
* A simple service test to make sure headers gets passed to and from service endpoints.

Fixes #370 