### PR TITLE
Publish - avoid async state machine when possible

### DIFF
--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -328,6 +328,8 @@ internal sealed class CommandWriter : IAsyncDisposable
         }
         finally
         {
+            _semLock.Release();
+
             payloadBuffer.Reset();
             _pool.Return(payloadBuffer);
 
@@ -336,8 +338,6 @@ internal sealed class CommandWriter : IAsyncDisposable
                 headersBuffer.Reset();
                 _pool.Return(headersBuffer);
             }
-
-            _semLock.Release();
         }
 
         return ValueTask.CompletedTask;

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -31,9 +31,7 @@ public sealed record NatsOpts
 
     public ILoggerFactory LoggerFactory { get; init; } = NullLoggerFactory.Instance;
 
-    // Same as default pipelines pause writer size
-    // Performing better compared to nats bench on localhost
-    public int WriterBufferSize { get; init; } = 65536;
+    public int WriterBufferSize { get; init; } = 1048576;
 
     public int ReaderBufferSize { get; init; } = 1048576;
 

--- a/tests/NATS.Client.Core.Tests/CancellationTest.cs
+++ b/tests/NATS.Client.Core.Tests/CancellationTest.cs
@@ -19,7 +19,7 @@ public class CancellationTest
         var cancellationToken = cts.Token;
 
         // stall the flush task
-        Assert.True(conn.CommandWriter.TestStallFlush());
+        var stallTask = conn.CommandWriter.TestStallFlushAsync(TimeSpan.FromSeconds(1));
 
         // commands that call ConnectAsync throw OperationCanceledException
         await Assert.ThrowsAsync<OperationCanceledException>(() => conn.PingAsync(cancellationToken).AsTask());
@@ -30,6 +30,8 @@ public class CancellationTest
             {
             }
         });
+
+        await stallTask;
     }
 
     // check that cancellation works on commands that call ConnectAsync


### PR DESCRIPTION
Brings back optimizations from prior to #346 

- Logic to skip async state machine when possible
- Locks switched back from channel-based to semaphore-based, but it appears they are faster
- Selective send memory consolidation
- Bigger send buffer sizes

Performed some benchmarks on Linux:

## Send 10 Million Messages Serially:

`main`:

```
Completed: 9999701, Awaited: 299

1,412,795 msgs/sec ~ 172.46 MB/sec
```

This PR:

```
Completed: 9999980, Awaited: 20

2,688,705 msgs/sec ~ 328.21 MB/sec
```

So around 1.9x more throughput.

## Publish Serial Microbench

`main`:

| Method       | Iter | Mean     | Error      | StdDev    | Allocated |
|------------- |----- |---------:|-----------:|----------:|----------:|
| **PublishAsync** | **64**   | **126.0 μs** |   **246.1 μs** |  **13.49 μs** |     **360 B** |
| **PublishAsync** | **512**  | **584.0 μs** | **2,328.1 μs** | **127.61 μs** |     **333 B** |
| **PublishAsync** | **1024** | **839.2 μs** |   **365.5 μs** |  **20.03 μs** |     **358 B** |

This PR:

| Method       | Iter | Mean     | Error      | StdDev    | Allocated |
|------------- |----- |---------:|-----------:|----------:|----------:|
| **PublishAsync** | **64**   | **127.1 μs** |   **258.8 μs** |  **14.19 μs** |     **321 B** |
| **PublishAsync** | **512**  | **377.8 μs** |   **677.4 μs** |  **37.13 μs** |     **336 B** |
| **PublishAsync** | **1024** | **750.7 μs** | **1,845.1 μs** | **101.14 μs** |     **339 B** |

Looks pretty similar

## Publish Parallel Microbench

`main`:

| Method               | Concurrency | Mean    | Error    | StdDev   | Gen0       | Gen1      | Allocated |
|--------------------- |------------ |--------:|---------:|---------:|-----------:|----------:|----------:|
| **PublishParallelAsync** | **1**           | **1.708 s** | **4.9311 s** | **0.2703 s** | **10000.0000** |         **-** |  **30.52 MB** |
| **PublishParallelAsync** | **2**           | **1.486 s** | **1.6187 s** | **0.0887 s** | **17000.0000** | **2000.0000** | **105.66 MB** |
| **PublishParallelAsync** | **4**           | **2.079 s** | **0.9243 s** | **0.0507 s** | **79000.0000** | **2000.0000** |  **256.4 MB** |

This PR:

| Method               | Concurrency | Mean    | Error    | StdDev   | Gen0        | Allocated |
|--------------------- |------------ |--------:|---------:|---------:|------------:|----------:|
| **PublishParallelAsync** | **1**           | **1.112 s** | **1.2659 s** | **0.0694 s** |  **10000.0000** |  **30.52 MB** |
| **PublishParallelAsync** | **2**           | **1.426 s** | **2.9107 s** | **0.1595 s** |  **61000.0000** | **180.45 MB** |
| **PublishParallelAsync** | **4**           | **2.096 s** | **0.4181 s** | **0.0229 s** | **216000.0000** | **640.77 MB** |

Faster at concurrency = 1, similar timing at 2 and 4.  Allocations jump in this PR quite a bit at concurrency = 4, although they don't escape Gen0.  Might be worth investigating why.