### PR TITLE
Fix NatsSvcServer start time format so that it's no longer culture aware

### DIFF
--- a/src/NATS.Client.Services/NatsSvcServer.cs
+++ b/src/NATS.Client.Services/NatsSvcServer.cs
@@ -40,7 +40,7 @@ public class NatsSvcServer : INatsSvcServer
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _channel = Channel.CreateBounded<SvcMsg>(32);
         _taskMsgLoop = Task.Run(MsgLoop);
-        _started = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
+        _started = DateTimeOffset.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z'");
     }
 
     /// <summary>


### PR DESCRIPTION
Changes the started time format in NatsSvcServer to `yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z'`  note the  added ' (ticks)  in  the format, this makes sure its NOT affected by current culture, see  [DateTimeFormatInfo.UniversalSortableDateTimePattern Property](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.datetimeformatinfo.universalsortabledatetimepattern?view=net-8.0) on how the "iso" format is specified in .Net

Fixes #372 