### PR TITLE
Send buffer fix

### DIFF
--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -43,6 +43,7 @@ internal sealed class CommandWriter : IAsyncDisposable
     private readonly PipeReader _pipeReader;
     private readonly PipeWriter _pipeWriter;
     private readonly SemaphoreSlim _semLock = new(1);
+    private readonly PartialSendFailureCounter _partialSendFailureCounter = new();
     private ISocketConnection? _socketConnection;
     private Task? _flushTask;
     private Task? _readerLoopTask;
@@ -92,6 +93,7 @@ internal sealed class CommandWriter : IAsyncDisposable
                     _pipeReader,
                     _channelSize,
                     _consolidateMem,
+                    _partialSendFailureCounter,
                     _ctsReader.Token)
                 .ConfigureAwait(false);
             });
@@ -429,6 +431,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         PipeReader pipeReader,
         Channel<int> channelSize,
         Memory<byte> consolidateMem,
+        PartialSendFailureCounter partialSendFailureCounter,
         CancellationToken cancellationToken)
     {
         try
@@ -465,23 +468,18 @@ internal sealed class CommandWriter : IAsyncDisposable
                             sendMem = consolidateMem[..consolidateLen];
                         }
 
+                        Exception? sendEx = null;
                         int sent;
                         try
                         {
                             sent = await connection.SendAsync(sendMem).ConfigureAwait(false);
                         }
-                        catch
+                        catch (Exception ex)
                         {
                             // we have no idea how many bytes were actually sent, so we have to assume they all were
                             // this could result in message loss, but is consistent with at-most once delivery
-                            if (pending > 0 && buffer.Length >= pending)
-                            {
-                                // throw away the rest of a partially sent command
-                                consumed = buffer.GetPosition(pending);
-                                examined = buffer.GetPosition(pending);
-                            }
-
-                            throw;
+                            sendEx = ex;
+                            sent = sendMem.Length;
                         }
 
                         var totalSize = 0;
@@ -525,6 +523,27 @@ internal sealed class CommandWriter : IAsyncDisposable
 
                         // slice the buffer for next iteration
                         buffer = buffer.Slice(sent);
+
+                        // throw if there was a send failure
+                        if (sendEx != null)
+                        {
+                            if (partialSendFailureCounter.ShouldFail())
+                            {
+                                if (pending > 0 && buffer.Length >= pending)
+                                {
+                                    // throw away the rest of a partially sent command
+                                    consumed = buffer.GetPosition(pending);
+                                    examined = buffer.GetPosition(pending);
+                                    while (!channelSize.Reader.TryRead(out _))
+                                    {
+                                        // should never happen; channel sizes are written before flush is called
+                                        await channelSize.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
+                                    }
+                                }
+                            }
+
+                            throw sendEx;
+                        }
                     }
                 }
                 finally
@@ -804,6 +823,24 @@ internal sealed class CommandWriter : IAsyncDisposable
         finally
         {
             _semLock.Release();
+        }
+    }
+
+    private class PartialSendFailureCounter
+    {
+        private const int MaxRetry = 2;
+        private readonly object _gate = new();
+        private int _count;
+
+        public bool ShouldFail()
+        {
+            lock (_gate)
+            {
+                if (++_count < MaxRetry)
+                    return false;
+                _count = 0;
+                return true;
+            }
         }
     }
 }

--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -500,7 +500,7 @@ internal sealed class CommandWriter : IAsyncDisposable
                             }
 
                             // don't mark the message as complete if we have more data to send
-                            //if (sendEx == null)
+                            if (sendEx == null)
                             {
                                 if (totalSize + pending > sent)
                                 {
@@ -508,10 +508,11 @@ internal sealed class CommandWriter : IAsyncDisposable
                                     break;
                                 }
                             }
-                            // else
-                            // {
-                                // sent = totalSize + pending;
-                            // }
+                            else
+                            {
+                                // if there was a send failure, we have to assume the message was sent
+                                sent = totalSize + pending;
+                            }
 
                             while (!channelSize.Reader.TryRead(out _))
                             {

--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -425,7 +425,8 @@ internal sealed class CommandWriter : IAsyncDisposable
         }
     }
 
-    private static async Task ReaderLoopAsync(ILogger<CommandWriter> logger,
+    private static async Task ReaderLoopAsync(
+        ILogger<CommandWriter> logger,
         ISocketConnection connection,
         PipeReader pipeReader,
         Channel<int> channelSize,

--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -500,11 +500,18 @@ internal sealed class CommandWriter : IAsyncDisposable
                             }
 
                             // don't mark the message as complete if we have more data to send
-                            if (totalSize + pending > sent)
+                            //if (sendEx == null)
                             {
-                                pending += totalSize - sent;
-                                break;
+                                if (totalSize + pending > sent)
+                                {
+                                    pending += totalSize - sent;
+                                    break;
+                                }
                             }
+                            // else
+                            // {
+                                // sent = totalSize + pending;
+                            // }
 
                             while (!channelSize.Reader.TryRead(out _))
                             {
@@ -552,10 +559,6 @@ internal sealed class CommandWriter : IAsyncDisposable
         catch (OperationCanceledException)
         {
             // Expected during shutdown
-        }
-        catch (InvalidOperationException)
-        {
-            // We might still be using the previous pipe reader which might be completed already
         }
         catch (Exception e)
         {

--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -468,8 +468,8 @@ internal sealed class CommandWriter : IAsyncDisposable
                             sendMem = consolidateMem[..consolidateLen];
                         }
 
-                        Exception? sendEx = null;
                         int sent;
+                        Exception? sendEx = null;
                         try
                         {
                             sent = await connection.SendAsync(sendMem).ConfigureAwait(false);
@@ -494,6 +494,7 @@ internal sealed class CommandWriter : IAsyncDisposable
                                 }
                             }
 
+                            // don't mark the message as complete if we have more data to send
                             if (totalSize + pending > sent)
                             {
                                 pending += totalSize - sent;

--- a/tests/NATS.Client.Core.Tests/ConnectionRetryTest.cs
+++ b/tests/NATS.Client.Core.Tests/ConnectionRetryTest.cs
@@ -64,7 +64,7 @@ public class ConnectionRetryTest
         await using var pubConn = server.CreateClientConnection();
         await pubConn.ConnectAsync();
 
-        var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var received = 0;
@@ -139,6 +139,6 @@ public class ConnectionRetryTest
         // after socket.WriteAsync returned, but before OS sent
         // check to ensure that the loss was < 1%
         var loss = 100.0 - (100.0 * received / sent);
-        Assert.True(loss <= 1.0, $"message loss of {loss:F}% was above 1% - {sent} sent, {received} received");
+        Assert.True(loss <= 5.0, $"message loss of {loss:F}% was above 1% - {sent} sent, {received} received");
     }
 }

--- a/tests/NATS.Client.Core.Tests/ConnectionRetryTest.cs
+++ b/tests/NATS.Client.Core.Tests/ConnectionRetryTest.cs
@@ -139,6 +139,6 @@ public class ConnectionRetryTest
         // after socket.WriteAsync returned, but before OS sent
         // check to ensure that the loss was < 1%
         var loss = 100.0 - (100.0 * received / sent);
-        Assert.True(loss <= 5.0, $"message loss of {loss:F}% was above 1% - {sent} sent, {received} received");
+        Assert.True(loss <= 1.0, $"message loss of {loss:F}% was above 1% - {sent} sent, {received} received");
     }
 }

--- a/tests/NATS.Client.Core.Tests/ConnectionRetryTest.cs
+++ b/tests/NATS.Client.Core.Tests/ConnectionRetryTest.cs
@@ -64,7 +64,7 @@ public class ConnectionRetryTest
         await using var pubConn = server.CreateClientConnection();
         await pubConn.ConnectAsync();
 
-        var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var received = 0;

--- a/tests/NATS.Client.Core.Tests/ProtocolTest.cs
+++ b/tests/NATS.Client.Core.Tests/ProtocolTest.cs
@@ -397,9 +397,11 @@ public class ProtocolTest
         for (var i = 0; i < 3; i++)
         {
             await Task.Delay(1_000, cts.Token);
+            var subjectCount = counts.Count;
             await server.RestartAsync();
             Interlocked.Increment(ref r);
-            await Task.Delay(1_000, cts.Token);
+
+            await Retry.Until("subject count goes up", () => counts.Count > subjectCount);
         }
 
         foreach (var log in logger.Logs.Where(x => x.EventId == NatsLogEvents.Protocol && x.LogLevel == LogLevel.Error))

--- a/tests/NATS.Client.Core.Tests/SendBufferTest.cs
+++ b/tests/NATS.Client.Core.Tests/SendBufferTest.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using NATS.Client.TestUtilities;
 
 namespace NATS.Client.Core.Tests;
@@ -12,7 +13,10 @@ public class SendBufferTest
     [Fact]
     public async Task Send_cancel()
     {
-        void Log(string m) => TmpFileLogger.Log(m);
+        // void Log(string m) => TmpFileLogger.Log(m);
+        void Log(string m)
+        {
+        }
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
@@ -26,7 +30,7 @@ public class SendBufferTest
                 }
             },
             Log,
-            cts.Token);
+            cancellationToken: cts.Token);
 
         Log("__________________________________");
 
@@ -73,6 +77,92 @@ public class SendBufferTest
         {
             Log($"[C] await tasks {i}...");
             await tasks[i];
+        }
+    }
+
+    [Fact]
+    public async Task Send_recover_half_sent()
+    {
+        void Log(string m) => TmpFileLogger.Log(m);
+        // void Log(string m)
+        // {
+        // }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await using var server = new MockServer(
+            handler: async (client, cmd) =>
+            {
+                if (cmd.Name == "PUB")
+                {
+                    _output.WriteLine($">> PUB {cmd.Subject}");
+                }
+
+                if (cmd is { Name: "PUB", Subject: "close" })
+                {
+                    client.Close();
+                }
+            },
+            Log,
+            info: $"{{\"max_payload\":{1024 * 1024 * 8}}}",
+            cancellationToken: cts.Token);
+
+        Log("__________________________________");
+
+        var testLogger = new InMemoryTestLoggerFactory(LogLevel.Error, m =>
+        {
+            Log($"[NC] {m.Message}");
+            if (m.Exception != null)
+                _output.WriteLine($"ERROR: {m.Exception}");
+        });
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            LoggerFactory = testLogger,
+        });
+
+        Log($"[C] connect {server.Url}");
+        await nats.ConnectAsync();
+
+        Log($"[C] ping");
+        var rtt = await nats.PingAsync(cts.Token);
+        Log($"[C] ping rtt={rtt}");
+
+        Log($"[C] publishing x...");
+        Log($">>>>>>>>>>>>>>>>>>> 1");
+        await nats.PublishAsync("x1", "x", cancellationToken: cts.Token);
+
+        Log($"[C] publishing 1M...");
+        Log($">>>>>>>>>>>>>>>>>>> 2");
+        var pubTask = nats.PublishAsync("close", new byte[1024 * 1024 * 8], cancellationToken: cts.Token).AsTask();
+
+        Log($">>>>>>>>>>>>>>>>>>> 3");
+        await pubTask.WaitAsync(cts.Token);
+
+        Log($">>>>>>>>>>>>>>>>>>> 4");
+        for (var i = 1; i <= 10; i++)
+        {
+            try
+            {
+                Log($">>>>>>>>>>>>>>>>>>> 5 ({i})");
+                await nats.PingAsync(cts.Token);
+                break;
+            }
+            catch (OperationCanceledException)
+            {
+                if (i == 10)
+                    throw;
+                await Task.Delay(10 * i, cts.Token);
+            }
+        }
+
+        await nats.PublishAsync("x2", "x", cancellationToken: cts.Token);
+
+        await nats.PingAsync(cts.Token);
+
+        foreach (var log in testLogger.Logs)
+        {
+            _output.WriteLine($"ERROR: {log.Exception?.Message}");
         }
     }
 }

--- a/tests/NATS.Client.Core.Tests/SendBufferTest.cs
+++ b/tests/NATS.Client.Core.Tests/SendBufferTest.cs
@@ -166,7 +166,8 @@ public class SendBufferTest
 
         Assert.Single(testLogger.Logs);
         Assert.True(testLogger.Logs[0].Exception is SocketException, "Socket exception expected");
-        Assert.Equal(SocketError.ConnectionReset, (testLogger.Logs[0].Exception as SocketException)?.SocketErrorCode);
+        var socketErrorCode = (testLogger.Logs[0].Exception as SocketException)!.SocketErrorCode;
+        Assert.True(socketErrorCode is SocketError.ConnectionReset or SocketError.Shutdown, "Socket error code");
 
         lock (pubs)
         {

--- a/tests/NATS.Client.Core.Tests/SendBufferTest.cs
+++ b/tests/NATS.Client.Core.Tests/SendBufferTest.cs
@@ -164,8 +164,7 @@ public class SendBufferTest
         Log($"[C] flush...");
         await nats.PingAsync(cts.Token);
 
-        // because of partial fail counter we would have two failed sends
-        Assert.Equal(2, testLogger.Logs.Count);
+        Assert.Equal(1, testLogger.Logs.Count);
         foreach (var log in testLogger.Logs)
         {
             Assert.True(log.Exception is SocketException, "Socket exception expected");
@@ -175,11 +174,10 @@ public class SendBufferTest
 
         lock (pubs)
         {
-            Assert.Equal(4, pubs.Count);
+            Assert.Equal(3, pubs.Count);
             Assert.Equal("PUB x1", pubs[0]);
             Assert.Equal("PUB close", pubs[1]);
-            Assert.Equal("PUB close", pubs[2]);
-            Assert.Equal("PUB x2", pubs[3]);
+            Assert.Equal("PUB x2", pubs[2]);
         }
     }
 }

--- a/tests/NATS.Client.Core.Tests/SendBufferTest.cs
+++ b/tests/NATS.Client.Core.Tests/SendBufferTest.cs
@@ -164,7 +164,7 @@ public class SendBufferTest
         Log($"[C] flush...");
         await nats.PingAsync(cts.Token);
 
-        Assert.Equal(1, testLogger.Logs.Count);
+        Assert.Equal(2, testLogger.Logs.Count);
         foreach (var log in testLogger.Logs)
         {
             Assert.True(log.Exception is SocketException, "Socket exception expected");
@@ -174,10 +174,11 @@ public class SendBufferTest
 
         lock (pubs)
         {
-            Assert.Equal(3, pubs.Count);
+            Assert.Equal(4, pubs.Count);
             Assert.Equal("PUB x1", pubs[0]);
             Assert.Equal("PUB close", pubs[1]);
-            Assert.Equal("PUB x2", pubs[2]);
+            Assert.Equal("PUB close", pubs[2]);
+            Assert.Equal("PUB x2", pubs[3]);
         }
     }
 }

--- a/tests/NATS.Client.Core.Tests/SendBufferTest.cs
+++ b/tests/NATS.Client.Core.Tests/SendBufferTest.cs
@@ -166,7 +166,6 @@ public class SendBufferTest
 
         Assert.Single(testLogger.Logs);
         Assert.True(testLogger.Logs[0].Exception is SocketException, "Socket exception expected");
-        Assert.Equal("An existing connection was forcibly closed by the remote host.", testLogger.Logs[0].Exception?.Message);
         Assert.Equal(SocketError.ConnectionReset, (testLogger.Logs[0].Exception as SocketException)?.SocketErrorCode);
 
         lock (pubs)

--- a/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
+++ b/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 
 namespace NATS.Client.TestUtilities;
 
-public class InMemoryTestLoggerFactory(LogLevel level) : ILoggerFactory
+public class InMemoryTestLoggerFactory(LogLevel level, Action<InMemoryTestLoggerFactory.LogMessage>? logger = null) : ILoggerFactory
 {
     private readonly List<LogMessage> _messages = new();
 
@@ -28,7 +28,11 @@ public class InMemoryTestLoggerFactory(LogLevel level) : ILoggerFactory
     private void Log(string categoryName, LogLevel logLevel, EventId eventId, Exception? exception, string message)
     {
         lock (_messages)
-            _messages.Add(new LogMessage(categoryName, logLevel, eventId, exception, message));
+        {
+            var logMessage = new LogMessage(categoryName, logLevel, eventId, exception, message);
+            _messages.Add(logMessage);
+            logger?.Invoke(logMessage);
+        }
     }
 
     public record LogMessage(string Category, LogLevel LogLevel, EventId EventId, Exception? Exception, string Message);

--- a/tests/NATS.Client.TestUtilities/MockServer.cs
+++ b/tests/NATS.Client.TestUtilities/MockServer.cs
@@ -85,7 +85,6 @@ public class MockServer : IAsyncDisposable
                                 }
 
                                 // Log($"[S] RCV PUB payload: {new string(buffer)}");
-
                                 await sr.ReadLineAsync();
                             }
                             else

--- a/tests/NATS.Client.TestUtilities/MockServer.cs
+++ b/tests/NATS.Client.TestUtilities/MockServer.cs
@@ -9,76 +9,91 @@ public class MockServer : IAsyncDisposable
 {
     private readonly Action<string> _logger;
     private readonly TcpListener _server;
+    private readonly List<Task> _clients = new();
     private readonly Task _accept;
+    private readonly CancellationTokenSource _cts;
 
     public MockServer(
-        Func<MockServer, Cmd, Task> handler,
+        Func<Client, Cmd, Task> handler,
         Action<string> logger,
-        CancellationToken cancellationToken)
+        string info = "{\"max_payload\":1048576}",
+        CancellationToken cancellationToken = default)
     {
         _logger = logger;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellationToken = _cts.Token;
         _server = new TcpListener(IPAddress.Parse("127.0.0.1"), 0);
-        _server.Start();
+        _server.Start(10);
         Port = ((IPEndPoint)_server.LocalEndpoint).Port;
 
         _accept = Task.Run(
             async () =>
             {
-                var client = await _server.AcceptTcpClientAsync();
-
-                var stream = client.GetStream();
-
-                var sw = new StreamWriter(stream, Encoding.ASCII);
-                await sw.WriteAsync("INFO {\"max_payload\":1048576}\r\n");
-                await sw.FlushAsync();
-
-                var sr = new StreamReader(stream, Encoding.ASCII);
-
+                var n = 0;
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    Log($"[S] >>> READ LINE");
-                    var line = (await sr.ReadLineAsync())!;
+                    var tcpClient = await _server.AcceptTcpClientAsync(cancellationToken);
+                    var client = new Client(this, tcpClient);
+                    n++;
+                    Log($"[S] [{n}] New client connected");
+                    var stream = tcpClient.GetStream();
 
-                    if (line.StartsWith("CONNECT"))
+                    var sw = new StreamWriter(stream, Encoding.ASCII);
+                    await sw.WriteAsync($"INFO {info}\r\n");
+                    await sw.FlushAsync();
+
+                    var sr = new StreamReader(stream, Encoding.ASCII);
+
+                    _clients.Add(Task.Run(async () =>
                     {
-                        Log($"[S] RCV CONNECT");
-                    }
-                    else if (line.StartsWith("PING"))
-                    {
-                        Log($"[S] RCV PING");
-                        await sw.WriteAsync("PONG\r\n");
-                        await sw.FlushAsync();
-                        Log($"[S] SND PONG");
-                    }
-                    else if (line.StartsWith("SUB"))
-                    {
-                        var m = Regex.Match(line, @"^SUB\s+(?<subject>\S+)");
-                        var subject = m.Groups["subject"].Value;
-                        Log($"[S] RCV SUB {subject}");
-                        await handler(this, new Cmd("SUB", subject, 0));
-                    }
-                    else if (line.StartsWith("PUB") || line.StartsWith("HPUB"))
-                    {
-                        var m = Regex.Match(line, @"^(H?PUB)\s+(?<subject>\S+).*?(?<size>\d+)$");
-                        var size = int.Parse(m.Groups["size"].Value);
-                        var subject = m.Groups["subject"].Value;
-                        Log($"[S] RCV PUB {subject} {size}");
-                        var read = 0;
-                        var buffer = new byte[size];
-                        while (read < size)
+                        while (!cancellationToken.IsCancellationRequested)
                         {
-                            var received = await stream.ReadAsync(buffer, read, size - read);
-                            read += received;
-                            Log($"[S] RCV {received} bytes (size={size} read={read})");
-                        }
+                            var line = (await sr.ReadLineAsync())!;
 
-                        await handler(this, new Cmd("PUB", subject, size));
-                        await sr.ReadLineAsync();
-                    }
-                    else
-                    {
-                        Log($"[S] RCV LINE: {line}");
-                    }
+                            if (line.StartsWith("CONNECT"))
+                            {
+                                Log($"[S] [{n}] RCV CONNECT");
+                            }
+                            else if (line.StartsWith("PING"))
+                            {
+                                Log($"[S] [{n}] RCV PING");
+                                await sw.WriteAsync("PONG\r\n");
+                                await sw.FlushAsync();
+                                Log($"[S] [{n}] SND PONG");
+                            }
+                            else if (line.StartsWith("SUB"))
+                            {
+                                var m = Regex.Match(line, @"^SUB\s+(?<subject>\S+)");
+                                var subject = m.Groups["subject"].Value;
+                                Log($"[S] [{n}] RCV SUB {subject}");
+                                await handler(client, new Cmd("SUB", subject, 0));
+                            }
+                            else if (line.StartsWith("PUB") || line.StartsWith("HPUB"))
+                            {
+                                var m = Regex.Match(line, @"^(H?PUB)\s+(?<subject>\S+).*?(?<size>\d+)$");
+                                var size = int.Parse(m.Groups["size"].Value);
+                                var subject = m.Groups["subject"].Value;
+                                Log($"[S] [{n}] RCV PUB {subject} {size}");
+                                await handler(client, new Cmd("PUB", subject, size));
+                                var read = 0;
+                                var buffer = new char[size];
+                                while (read < size)
+                                {
+                                    var received = await sr.ReadAsync(buffer, read, size - read);
+                                    read += received;
+                                    Log($"[S] [{n}] RCV {received} bytes (size={size} read={read})");
+                                }
+
+                                // Log($"[S] RCV PUB payload: {new string(buffer)}");
+
+                                await sr.ReadLineAsync();
+                            }
+                            else
+                            {
+                                Log($"[S] [{n}] RCV LINE: {line}");
+                            }
+                        }
+                    }));
                 }
             },
             cancellationToken);
@@ -90,7 +105,28 @@ public class MockServer : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        _cts.Cancel();
         _server.Stop();
+        foreach (var client in _clients)
+        {
+            try
+            {
+                await client;
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (SocketException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+        }
+
         try
         {
             await _accept;
@@ -109,4 +145,20 @@ public class MockServer : IAsyncDisposable
     public void Log(string m) => _logger(m);
 
     public record Cmd(string Name, string Subject, int Size);
+
+    public class Client
+    {
+        private readonly MockServer _server;
+        private readonly TcpClient _tcpClient;
+
+        public Client(MockServer server, TcpClient tcpClient)
+        {
+            _server = server;
+            _tcpClient = tcpClient;
+        }
+
+        public void Log(string m) => _server.Log(m);
+
+        public void Close() => _tcpClient.Close();
+    }
 }


### PR DESCRIPTION
If server drops the connection halfway through sending a large message pipelines reader was not recovering after reconnect. With this fix we consider the pending message sent if there were any socket send errors.

PS I could not reproduce the issue connecting to nats-server (hence used the mock server) but the error can be reproduced if proactive max_payload check is commented out. Just try to publish a payload larger than 1MB then try to publish or ping after that. Even though client reconnects you'd see pipeline exceptions: `System.InvalidOperationException: The examined position cannot be less than the previously examined position.`