### PR TITLE
Buffer defaults avoiding LOH

### DIFF
--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -23,6 +23,9 @@ internal sealed class CommandWriter : IAsyncDisposable
     // assuming 40 bytes TCP overhead + 40 bytes TLS overhead per packet
     private const int SendMemSize = 8520;
 
+    // set to a reasonable socket write mem size
+    private const int MinSegmentSize = 65536;
+
     private readonly ILogger<CommandWriter> _logger;
     private readonly NatsConnection _connection;
     private readonly ObjectPool _pool;
@@ -69,7 +72,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         var pipe = new Pipe(new PipeOptions(
             pauseWriterThreshold: opts.WriterBufferSize, // flush will block after hitting
             resumeWriterThreshold: opts.WriterBufferSize / 2,
-            minimumSegmentSize: opts.WriterBufferSize / 16,
+            minimumSegmentSize: MinSegmentSize,
             useSynchronizationContext: false));
         _pipeReader = pipe.Reader;
         _pipeWriter = pipe.Writer;

--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -24,7 +24,7 @@ internal sealed class CommandWriter : IAsyncDisposable
     private const int SendMemSize = 8520;
 
     // set to a reasonable socket write mem size
-    private const int MinSegmentSize = 65536;
+    private const int MinSegmentSize = 16384;
 
     private readonly ILogger<CommandWriter> _logger;
     private readonly NatsConnection _connection;

--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -23,7 +23,8 @@ internal sealed class CommandWriter : IAsyncDisposable
     // assuming 40 bytes TCP overhead + 40 bytes TLS overhead per packet
     private const int SendMemSize = 8520;
 
-    // set to a reasonable socket write mem size
+    // should be more than SendMemSize
+    // https://github.com/nats-io/nats.net.v2/pull/383#discussion_r1484344102
     private const int MinSegmentSize = 16384;
 
     private readonly ILogger<CommandWriter> _logger;

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -31,9 +31,9 @@ public sealed record NatsOpts
 
     public ILoggerFactory LoggerFactory { get; init; } = NullLoggerFactory.Instance;
 
-    public int WriterBufferSize { get; init; } = 1048576;
+    public int WriterBufferSize { get; init; } = 65536;
 
-    public int ReaderBufferSize { get; init; } = 1048576;
+    public int ReaderBufferSize { get; init; } = 65536;
 
     public bool UseThreadPoolCallback { get; init; } = false;
 


### PR DESCRIPTION
Changed buffer defaults from 1m to 64k to avoid allocating in LOH for better GC performance and memory utilisation.
* Changed pipeline segment size to be configured based on write buffer size
* Used `PoolingAsyncValueTaskMethodBuilder` for publish to reduce allocations

# Generations and memory utilisation

## 1m
![image](https://github.com/nats-io/nats.net.v2/assets/386903/435d782c-ccc7-456b-9ddf-76f2b00eb932)
![image](https://github.com/nats-io/nats.net.v2/assets/386903/faaca72d-b161-4ef2-8a69-cf059e3c1482)

## 64k
![image](https://github.com/nats-io/nats.net.v2/assets/386903/71eb6e67-16bc-4ed9-9212-fdc343d64824)
![image](https://github.com/nats-io/nats.net.v2/assets/386903/178f63b2-94a7-4b8e-9ef6-391a358c2cd2)

# BDN
| Method       | Iter | BufferSize | Mean     | Error     | StdDev  | Allocated |
|------------- |----- |----------- |---------:|----------:|--------:|----------:|
| PublishAsync | 64   | 65536      | 143.8 us |  59.51 us | 3.26 us |     372 B |
| PublishAsync | 64   | 1048576    | 155.8 us |  21.27 us | 1.17 us |     339 B |
| PublishAsync | 512  | 65536      | 299.2 us | 111.81 us | 6.13 us |     338 B |
| PublishAsync | 512  | 1048576    | 310.9 us |  99.12 us | 5.43 us |     359 B |
| PublishAsync | 1024 | 65536      | 471.8 us |  27.99 us | 1.53 us |     367 B |
| PublishAsync | 1024 | 1048576    | 466.2 us |  11.03 us | 0.60 us |     358 B |

| Method               | Concurrency | BufferSize | Mean       | Error       | StdDev   | Gen0       | Gen1       | Allocated |
|--------------------- |------------ |----------- |-----------:|------------:|---------:|-----------:|-----------:|----------:|
| PublishParallelAsync | 1           | 65536      | 1,016.0 ms |    54.64 ms |  2.99 ms |  2000.0000 |  2000.0000 |  31.73 MB |
| PublishParallelAsync | 1           | 1048576    |   818.9 ms |    61.73 ms |  3.38 ms |  2000.0000 |          - |  30.64 MB |
| PublishParallelAsync | 2           | 65536      | 1,344.3 ms |   111.71 ms |  6.12 ms | 20000.0000 | 20000.0000 | 268.69 MB |
| PublishParallelAsync | 2           | 1048576    | 1,179.1 ms | 1,215.59 ms | 66.63 ms | 15000.0000 |          - |    197 MB |
| PublishParallelAsync | 4           | 65536      | 1,795.2 ms |    95.90 ms |  5.26 ms | 36000.0000 | 36000.0000 | 473.06 MB |
| PublishParallelAsync | 4           | 1048576    | 1,756.2 ms |    44.28 ms |  2.43 ms | 36000.0000 |  1000.0000 | 473.91 MB |

# Compared to main
main
| Method       | Iter | Mean     | Error    | StdDev  | Allocated |
|------------- |----- |---------:|---------:|--------:|----------:|
| PublishAsync | 64   | 160.0 us |  3.81 us | 0.21 us |     363 B |
| PublishAsync | 512  | 314.3 us | 33.90 us | 1.86 us |     346 B |
| PublishAsync | 1024 | 467.7 us | 36.57 us | 2.00 us |     352 B |

this PR
| Method       | Iter | Mean     | Error    | StdDev  | Allocated |
|------------- |----- |---------:|---------:|--------:|----------:|
| PublishAsync | 64   | 146.2 us | 50.60 us | 2.77 us |     366 B |
| PublishAsync | 512  | 296.2 us | 32.33 us | 1.77 us |     370 B |
| PublishAsync | 1024 | 472.6 us | 27.21 us | 1.49 us |     374 B |

# nats bench
Run on Windows 11
```
msgs=100,000,000, msgsize=128 B

Go  Sub stats: 2,236,818 msgs/sec ~ 273.05 MB/sec
1m  Sub stats: 1,971,795 msgs/sec ~ 240.70 MB/sec
64k Sub stats: 2,491,563 msgs/sec ~ 304.15 MB/sec

Go  Sub stats: 2,245,381 msgs/sec ~ 274.09 MB/sec
1m  Sub stats: 1,996,122 msgs/sec ~ 243.67 MB/sec
64k Sub stats: 2,539,671 msgs/sec ~ 310.02 MB/sec

Go  Sub stats: 2,256,865 msgs/sec ~ 275.50 MB/sec
1m  Sub stats: 1,991,243 msgs/sec ~ 243.07 MB/sec
64k Sub stats: 2,538,869 msgs/sec ~ 309.92 MB/sec
```

# Program.cs
This is used both for dotMemory and nats bench runs.
```csharp
using JetBrains.Profiler.Api;
using NATS.Client.Core;

Console.WriteLine("start");

// const int size = 1048576;
const int size = 65536;

var natsOpts = new NatsOpts
{
    Url = "127.0.0.1:4333",
    ReaderBufferSize = size,
    WriterBufferSize = size,
};

Console.WriteLine($"ReaderBufferSize:{natsOpts.ReaderBufferSize:n0}");
Console.WriteLine($"WriterBufferSize:{natsOpts.WriterBufferSize:n0}");

await using var nats = new NatsConnection(natsOpts);

MemoryProfiler.CollectAllocations(true);

var data = new byte[128];

for (var i = 0; i < 100_000_000; i++)
{
    await nats.PublishAsync("x", data);

    if (i == 10_000_000)
    {
        Console.WriteLine("snapshot_10");
        MemoryProfiler.GetSnapshot("snapshot_10");
    }

    if (i == 50_000_000)
    {
        Console.WriteLine("snapshot_50");
        MemoryProfiler.GetSnapshot("snapshot_50");
    }

    if (i == 90_000_000)
    {
        Console.WriteLine("snapshot_90");
        MemoryProfiler.GetSnapshot("snapshot_90");
    }
}

await nats.PingAsync();

Console.WriteLine("done");
```