### PR TITLE
Add nkey and sha512 micro benchmarks and sanity check tests

### DIFF
--- a/sandbox/MicroBenchmark/NKeyBench.cs
+++ b/sandbox/MicroBenchmark/NKeyBench.cs
@@ -1,0 +1,26 @@
+using BenchmarkDotNet.Attributes;
+using NATS.Client.Core;
+
+namespace MicroBenchmark;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+[PlainExporter]
+public class NKeyBench
+{
+    [Params(5000)]
+    public int Iter { get; set; }
+
+    [Benchmark]
+    public int NKeyCreate()
+    {
+        var result = 0;
+        for (var i = 0; i < Iter; i++)
+        {
+            var nkey = NKeys.FromSeed("SUAAVWRZG6M5FA5VRRGWSCIHKTOJC7EWNIT4JV3FTOIPO4OBFR5WA7X5TE");
+            result += nkey.PublicKey.Length;
+        }
+
+        return result;
+    }
+}

--- a/sandbox/MicroBenchmark/Sha512Bench.cs
+++ b/sandbox/MicroBenchmark/Sha512Bench.cs
@@ -1,0 +1,39 @@
+using BenchmarkDotNet.Attributes;
+using NATS.Client.Core.NaCl;
+
+namespace MicroBenchmark;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+[PlainExporter]
+public class Sha512TBench
+{
+    private byte[] _data = default!;
+
+    [Params(5000)]
+    public int Iter { get; set; }
+
+    [Params(1024, 1024 * 25)]
+    public int DataSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(4711);
+        _data = new byte[DataSize];
+        random.NextBytes(_data);
+    }
+
+    [Benchmark]
+    public int Sha512Hash()
+    {
+        var result = 0;
+        for (var i = 0; i < Iter; i++)
+        {
+            var hash = Sha512.Hash(_data, 0, _data.Length)!;
+            result += hash.Length;
+        }
+
+        return result;
+    }
+}

--- a/tests/NATS.Client.Core.Tests/NKeyTests.cs
+++ b/tests/NATS.Client.Core.Tests/NKeyTests.cs
@@ -1,0 +1,39 @@
+using NATS.Client.Core.NaCl;
+
+namespace NATS.Client.Core.Tests;
+
+public class NKeyTests
+{
+    [Fact]
+    public void NKey_Seed_And_Sign()
+    {
+        const string seed = "SUAAVWRZG6M5FA5VRRGWSCIHKTOJC7EWNIT4JV3FTOIPO4OBFR5WA7X5TE";
+        const string expectedSignedResult = "49C5CC75BAA40FAFFD1B8FD9FE5B008A781EC4FF6C7DE18B64C7457B80BDA2A1B2DB556DCA02F8989469088D0D08A0BC3A07E05765CE6EA141F199C2F9EC5D03";
+        const string expectedPublicKey = "170932F19001FCDD0618D214E92EC26B04599B5C2A36755843CDC23F650193CF";
+        var dataToSign = "Hello World"u8;
+
+        var nKey = NKeys.FromSeed(seed);
+
+        // Sanity check public key
+        var actualPublicKey = Convert.ToHexString(nKey.PublicKey);
+        Assert.Equal(expectedPublicKey, actualPublicKey);
+
+        // Sign and verify
+        var signedData = nKey.Sign(dataToSign.ToArray());
+        var actual = Convert.ToHexString(signedData);
+
+        Assert.Equal(expectedSignedResult, actual);
+    }
+
+    [Fact]
+    public void Sha512_Hash()
+    {
+        var dataToHash = "Can I Haz Hash please?"u8;
+        const string ExpectedHash = "B8B57504AD522AC43AF52CB86BB10D315840C7D1B80BDF3A2524654F7C2C3B07C601ADD320E9F870A6FA8DA3003CFA1BE330133D0ABED7CE49F9251D2BB97421";
+
+        var dataArray = dataToHash.ToArray();
+        var actual = Convert.ToHexString(Sha512.Hash(dataArray, 0, dataArray.Length));
+
+        Assert.Equal(ExpectedHash, actual);
+    }
+}


### PR DESCRIPTION
In preparation for replacing the internal implementation of Sha512 with the Sha512 built in to the .Net framework.

The current numbers for reference:

```shell
BenchmarkDotNet v0.13.12, macOS Sonoma 14.3.1 (23D60) [Darwin 23.3.0]
Apple M2 Pro, 1 CPU, 12 logical and 12 physical cores
.NET SDK 8.0.101
  [Host]   : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD
  ShortRun : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

| Method     | Iter | Mean     | Error   | StdDev  | Gen0     | Allocated |
|----------- |----- |---------:|--------:|--------:|---------:|----------:|
| NKeyCreate | 5000 | 142.9 ms | 5.23 ms | 0.29 ms | 500.0000 |   4.08 MB |

| Method     | Iter | DataSize | Mean      | Error    | StdDev   | Gen0     | Allocated |
|----------- |----- |--------- |----------:|---------:|---------:|---------:|----------:|
| Sha512Hash | 5000 | 1024     |  17.95 ms | 0.346 ms | 0.019 ms | 187.5000 |    1.6 MB |
| Sha512Hash | 5000 | 25600    | 396.04 ms | 4.489 ms | 0.246 ms |        - |    1.6 MB |

```