### PR TITLE
Gracefully close sockets

### DIFF
--- a/src/NATS.Client.Core/Internal/SslStreamConnection.cs
+++ b/src/NATS.Client.Core/Internal/SslStreamConnection.cs
@@ -27,11 +27,7 @@ internal sealed class SslStreamConnection : ISocketConnection
 
     public Task<Exception> WaitForClosed => _waitForClosedSource.Task;
 
-#if NET6_0
-    public ValueTask DisposeAsync()
-#else
     public async ValueTask DisposeAsync()
-#endif
     {
         if (Interlocked.Increment(ref _disposed) == 1)
         {
@@ -47,11 +43,9 @@ internal sealed class SslStreamConnection : ISocketConnection
             catch
             {
             }
-        }
 
-#if NET6_0
-        return ValueTask.CompletedTask;
-#endif
+            await _sslStream.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/NATS.Client.Core/Internal/TcpConnection.cs
+++ b/src/NATS.Client.Core/Internal/TcpConnection.cs
@@ -103,10 +103,18 @@ internal sealed class TcpConnection : ISocketConnection
             {
             }
 
+            try
+            {
+                _socket.Shutdown(SocketShutdown.Both);
+            }
+            catch
+            {
+            }
+
             _socket.Dispose();
         }
 
-        return default;
+        return ValueTask.CompletedTask;
     }
 
     // when catch SocketClosedException, call this method.

--- a/tests/NATS.Client.TestUtilities/MockServer.cs
+++ b/tests/NATS.Client.TestUtilities/MockServer.cs
@@ -48,7 +48,12 @@ public class MockServer : IAsyncDisposable
                     {
                         while (!cancellationToken.IsCancellationRequested)
                         {
-                            var line = (await sr.ReadLineAsync())!;
+                            var line = await sr.ReadLineAsync();
+                            if (line == null)
+                            {
+                                // empty read, socket closed
+                                return;
+                            }
 
                             if (line.StartsWith("CONNECT"))
                             {


### PR DESCRIPTION
When watching wireshark, I noticed a lot of `RST` instead of graceful `FIN`

So looking into it more

- TCP Socket - calling `_socket.Shutdown(SocketShutdown.Both);` seems to resolve the RST
- SSL - I guess we forgot to Dispose the SSLStream?  oops.  adding the Dispose still results in a RST on Linux in some cases though, but I'm not sure there is much we can do about it
- WebSocket - needed to call `CloseAsync` which looks like it actually does send another application-level packet, so I included a timeout on that.  But I am guessing if the socket is already disconnected that will return immediately with an exception