### PR TITLE
Implement Consumers Pause

### DIFF
--- a/src/NATS.Client.JetStream/INatsJSContext.cs
+++ b/src/NATS.Client.JetStream/INatsJSContext.cs
@@ -91,6 +91,33 @@ public interface INatsJSContext
     ValueTask<bool> DeleteConsumerAsync(string stream, string consumer, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Pause a consumer.
+    /// </summary>
+    /// <param name="stream">Stream name where consumer is associated to.</param>
+    /// <param name="consumer">Consumer name to be paused.</param>
+    /// <param name="pauseUntil">Until when the consumer should be paused.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>Result of pausing the consumer.</returns>
+    /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
+    /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="stream"/> name is invalid.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="stream"/> name is <c>null</c>.</exception>
+    ValueTask<ConsumerPauseResponse> PauseConsumerAsync(string stream, string consumer, DateTimeOffset pauseUntil, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resume a (paused) consumer.
+    /// </summary>
+    /// <param name="stream">Stream name where consumer is associated to.</param>
+    /// <param name="consumer">Consumer name to be resumed.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>Result of resuming the (paused) consumer.</returns>
+    /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
+    /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="stream"/> name is invalid.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="stream"/> name is <c>null</c>.</exception>
+    ValueTask<bool> ResumeConsumerAsync(string stream, string consumer, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Calls JetStream Account Info API.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>

--- a/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSJsonSerializer.cs
@@ -45,6 +45,8 @@ internal static class NatsJSJsonSerializer<T>
 [JsonSerializable(typeof(ConsumerListResponse))]
 [JsonSerializable(typeof(ConsumerNamesRequest))]
 [JsonSerializable(typeof(ConsumerNamesResponse))]
+[JsonSerializable(typeof(ConsumerPauseRequest))]
+[JsonSerializable(typeof(ConsumerPauseResponse))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(ExternalStreamSource))]
 [JsonSerializable(typeof(IterableRequest))]
@@ -334,4 +336,31 @@ internal class NatsJSJsonNanosecondsConverter : JsonConverter<TimeSpan>
 
     public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) =>
         writer.WriteNumberValue((long)(value.TotalMilliseconds * 1_000_000L));
+}
+
+internal class NatsJSJsonNullableNanosecondsConverter : JsonConverter<TimeSpan?>
+{
+    private readonly NatsJSJsonNanosecondsConverter _converter = new();
+
+    public override TimeSpan? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        return _converter.Read(ref reader, typeToConvert, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, TimeSpan? value, JsonSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            _converter.Write(writer, value.Value, options);
+        }
+    }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -235,6 +235,13 @@ public record ConsumerConfig
     public long NumReplicas { get; set; }
 
     /// <summary>
+    /// If the consumer is paused, this contains until which time it is paused.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("pause_until")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public DateTimeOffset? PauseUntil { get; set; }
+
+    /// <summary>
     /// Force the consumer state to be kept in memory rather than inherit the setting from the stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("mem_storage")]

--- a/src/NATS.Client.JetStream/Models/ConsumerInfo.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerInfo.cs
@@ -104,10 +104,10 @@ public record ConsumerInfo
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("paused")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public bool Paused { get; set; }
+    public bool IsPaused { get; set; }
 
     /// <summary>
-    /// If the consumer is <see cref="Paused"/>, this contains how much time is remaining until this consumer is unpaused.
+    /// If the consumer is <see cref="IsPaused"/>, this contains how much time is remaining until this consumer is unpaused.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("pause_remaining")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]

--- a/src/NATS.Client.JetStream/Models/ConsumerInfo.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerInfo.cs
@@ -1,3 +1,5 @@
+using NATS.Client.JetStream.Internal;
+
 namespace NATS.Client.JetStream.Models;
 
 public record ConsumerInfo
@@ -96,6 +98,21 @@ public record ConsumerInfo
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Range(ulong.MinValue, ulong.MaxValue)]
     public ulong NumPending { get; set; }
+
+    /// <summary>
+    /// Whether the consumer is paused.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("paused")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public bool Paused { get; set; }
+
+    /// <summary>
+    /// If the consumer is <see cref="Paused"/>, this contains how much time is remaining until this consumer is unpaused.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("pause_remaining")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonNullableNanosecondsConverter))]
+    public TimeSpan? PauseRemaining { get; set; }
 
     [System.Text.Json.Serialization.JsonPropertyName("cluster")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]

--- a/src/NATS.Client.JetStream/Models/ConsumerPauseRequest.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerPauseRequest.cs
@@ -1,0 +1,11 @@
+namespace NATS.Client.JetStream.Models;
+
+/// <summary>
+/// A request to the JetStream $JS.API.CONSUMER.PAUSE API
+/// </summary>
+internal record ConsumerPauseRequest
+{
+    [System.Text.Json.Serialization.JsonPropertyName("pause_until")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public DateTimeOffset? PauseUntil { get; set; }
+}

--- a/src/NATS.Client.JetStream/Models/ConsumerPauseResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerPauseResponse.cs
@@ -9,14 +9,14 @@ public record ConsumerPauseResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("paused")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    public bool Paused { get; set; }
+    public bool IsPaused { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("pause_until")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public DateTimeOffset PauseUntil { get; set; }
+    public DateTimeOffset PauseUntil { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("pause_remaining")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonNullableNanosecondsConverter))]
-    public TimeSpan? PauseRemaining { get; set; }
+    public TimeSpan? PauseRemaining { get; init; }
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerPauseResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerPauseResponse.cs
@@ -1,0 +1,22 @@
+using NATS.Client.JetStream.Internal;
+
+namespace NATS.Client.JetStream.Models;
+
+/// <summary>
+/// A response from the JetStream $JS.API.CONSUMER.PAUSE API
+/// </summary>
+public record ConsumerPauseResponse
+{
+    [System.Text.Json.Serialization.JsonPropertyName("paused")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
+    public bool Paused { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("pause_until")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public DateTimeOffset PauseUntil { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("pause_remaining")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonNullableNanosecondsConverter))]
+    public TimeSpan? PauseRemaining { get; set; }
+}

--- a/src/NATS.Client.JetStream/Models/ConsumerPauseResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerPauseResponse.cs
@@ -9,14 +9,26 @@ public record ConsumerPauseResponse
 {
     [System.Text.Json.Serialization.JsonPropertyName("paused")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
+#if NET6_0
+    public bool IsPaused { get; set; }
+#else
     public bool IsPaused { get; init; }
+#endif
 
     [System.Text.Json.Serialization.JsonPropertyName("pause_until")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+#if NET6_0
+    public DateTimeOffset PauseUntil { get; set; }
+#else
     public DateTimeOffset PauseUntil { get; init; }
+#endif
 
     [System.Text.Json.Serialization.JsonPropertyName("pause_remaining")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonNullableNanosecondsConverter))]
+#if NET6_0
+    public TimeSpan? PauseRemaining { get; set; }
+#else
     public TimeSpan? PauseRemaining { get; init; }
+#endif
 }

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -152,6 +152,49 @@ public partial class NatsJSContext : INatsJSContext
         return response.Success;
     }
 
+    /// <summary>
+    /// Pause a consumer.
+    /// </summary>
+    /// <param name="stream">Stream name where consumer is associated to.</param>
+    /// <param name="consumer">Consumer name to be paused.</param>
+    /// <param name="pauseUntil">Until when the consumer should be paused.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>Result of pausing the consumer.</returns>
+    /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
+    /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="stream"/> name is invalid.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="stream"/> name is <c>null</c>.</exception>
+    public async ValueTask<ConsumerPauseResponse> PauseConsumerAsync(string stream, string consumer, DateTimeOffset pauseUntil, CancellationToken cancellationToken = default)
+    {
+        ThrowIfInvalidStreamName(stream);
+        var response = await JSRequestResponseAsync<ConsumerPauseRequest, ConsumerPauseResponse>(
+            subject: $"{Opts.Prefix}.CONSUMER.PAUSE.{stream}.{consumer}",
+            request: new ConsumerPauseRequest { PauseUntil = pauseUntil },
+            cancellationToken);
+        return response;
+    }
+
+    /// <summary>
+    /// Resume a (paused) consumer.
+    /// </summary>
+    /// <param name="stream">Stream name where consumer is associated to.</param>
+    /// <param name="consumer">Consumer name to be resumed.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>Result of resuming the (paused) consumer.</returns>
+    /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
+    /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="stream"/> name is invalid.</exception>
+    /// <exception cref="ArgumentNullException">The <paramref name="stream"/> name is <c>null</c>.</exception>
+    public async ValueTask<bool> ResumeConsumerAsync(string stream, string consumer, CancellationToken cancellationToken = default)
+    {
+        ThrowIfInvalidStreamName(stream);
+        var response = await JSRequestResponseAsync<object, ConsumerPauseResponse>(
+            subject: $"{Opts.Prefix}.CONSUMER.PAUSE.{stream}.{consumer}",
+            request: null,
+            cancellationToken);
+        return !response.Paused;
+    }
+
     internal ValueTask<ConsumerInfo> CreateOrderedConsumerInternalAsync(
         string stream,
         NatsJSOrderedConsumerOpts opts,

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -192,7 +192,7 @@ public partial class NatsJSContext : INatsJSContext
             subject: $"{Opts.Prefix}.CONSUMER.PAUSE.{stream}.{consumer}",
             request: null,
             cancellationToken);
-        return !response.Paused;
+        return !response.IsPaused;
     }
 
     internal ValueTask<ConsumerInfo> CreateOrderedConsumerInternalAsync(

--- a/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
@@ -62,7 +62,7 @@ public class ConsumerSetupTest
         var consumer = await js.GetConsumerAsync("s1", "c1", cts.Token);
 
         var info = consumer.Info;
-        Assert.True(info.Paused);
+        Assert.True(info.IsPaused);
 
         var config = info.Config;
         Assert.Equal(pauseUntil, config.PauseUntil);

--- a/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
@@ -37,16 +37,16 @@ public class ConsumerSetupTest
         Assert.Equal("q1", config.DeliverGroup);
     }
 
-    [Fact]
+    [SkipIfNatsServer(versionEarlierThan: "2.11")]
     public async Task Create_paused_consumer()
     {
         await using var server = NatsServer.StartJS();
         await using var nats = server.CreateClientConnection();
-        var js = new NatsJSContext(nats);
+        var js = new NatsJSContextFactory().CreateContext(nats);
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        await js.CreateStreamAsync(new StreamConfig("s1", new[] { "s1.*" }), cts.Token);
 
         var pauseUntil = DateTimeOffset.Now.AddHours(1);
 

--- a/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
@@ -36,4 +36,35 @@ public class ConsumerSetupTest
         Assert.Equal("i1", config.DeliverSubject);
         Assert.Equal("q1", config.DeliverGroup);
     }
+
+    [Fact]
+    public async Task Create_paused_consumer()
+    {
+        await using var server = NatsServer.StartJS();
+        await using var nats = server.CreateClientConnection();
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+
+        var pauseUntil = DateTimeOffset.Now.AddHours(1);
+
+        await js.CreateOrUpdateConsumerAsync(
+            stream: "s1",
+            config: new ConsumerConfig
+            {
+                Name = "c1",
+                PauseUntil = pauseUntil,
+            },
+            cancellationToken: cts.Token);
+
+        var consumer = await js.GetConsumerAsync("s1", "c1", cts.Token);
+
+        var info = consumer.Info;
+        Assert.True(info.Paused);
+
+        var config = info.Config;
+        Assert.Equal(pauseUntil, config.PauseUntil);
+    }
 }

--- a/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
@@ -99,11 +99,11 @@ public class ManageConsumerTest
         {
             var consumerPauseResponse = await js.PauseConsumerAsync("s1", "c1", pauseUntil, cts.Token);
 
-            Assert.True(consumerPauseResponse.Paused);
+            Assert.True(consumerPauseResponse.IsPaused);
             Assert.Equal(pauseUntil, consumerPauseResponse.PauseUntil);
 
             var consumerInfo = await js.GetConsumerAsync("s1", "c1", cts.Token);
-            Assert.True(consumerInfo.Info.Paused);
+            Assert.True(consumerInfo.Info.IsPaused);
             Assert.Equal(pauseUntil, consumerInfo.Info.Config.PauseUntil);
         }
 
@@ -113,7 +113,7 @@ public class ManageConsumerTest
             Assert.True(isResumed);
 
             var consumerInfo = await js.GetConsumerAsync("s1", "c1", cts.Token);
-            Assert.False(consumerInfo.Info.Paused);
+            Assert.False(consumerInfo.Info.IsPaused);
             Assert.Null(consumerInfo.Info.Config.PauseUntil);
         }
     }

--- a/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
@@ -60,6 +60,10 @@ public class NatsKVContextFactoryTest
 
         public ValueTask<bool> DeleteConsumerAsync(string stream, string consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
+        public ValueTask<ConsumerPauseResponse> PauseConsumerAsync(string stream, string consumer, DateTimeOffset pauseUntil, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public ValueTask<bool> ResumeConsumerAsync(string stream, string consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
         public ValueTask<AccountInfoResponse> GetAccountInfoAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public ValueTask<PubAckResponse> PublishAsync<T>(string subject, T? data, INatsSerialize<T>? serializer = default, NatsJSPubOpts? opts = default, NatsHeaders? headers = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/tests/NATS.Client.ObjectStore.Tests/NatsObjContextFactoryTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/NatsObjContextFactoryTest.cs
@@ -60,6 +60,10 @@ public class NatsObjContextFactoryTest
 
         public ValueTask<bool> DeleteConsumerAsync(string stream, string consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
+        public ValueTask<ConsumerPauseResponse> PauseConsumerAsync(string stream, string consumer, DateTimeOffset pauseUntil, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public ValueTask<bool> ResumeConsumerAsync(string stream, string consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
         public ValueTask<AccountInfoResponse> GetAccountInfoAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public ValueTask<PubAckResponse> PublishAsync<T>(string subject, T? data, INatsSerialize<T>? serializer = default, NatsJSPubOpts? opts = default, NatsHeaders? headers = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats.net.v2/issues/416

Adds support for pausing and resuming consumers.

- The `NatsJSContext.Consumers` now has methods to `PauseConsumerAsync(stream, consumer, pauseUntil)`, as well as `ResumeConsumerAsync(stream, consumer)`.
- `ConsumerConfiguration` now has support for setting `PauseUntil` as well. Allowing to set it during consumer creation.


The implementation is similar to and based on the changes I made for the Java client: https://github.com/nats-io/nats.java/pull/1093

Am not too familiar with .NET, and this is the first time contributing to this client. Please let me know if I'm missing any things specific to .NET or this client, that can be improved further.