### PR TITLE
Added DuplicateWindow to NatsKVConfig

### DIFF
--- a/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
@@ -61,11 +61,6 @@ public record NatsKVConfig
     /// </summary>
     public bool Compression { get; init; }
 
-    /// <summary>
-    /// The time window to track duplicate messages for
-    /// </summary>
-    public TimeSpan? DuplicateWindow { get; init; } = null;
-
     // TODO: Bucket mirror configuration.
     // pub mirror: Option<Source>,
     // Bucket sources configuration.

--- a/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
@@ -61,6 +61,11 @@ public record NatsKVConfig
     /// </summary>
     public bool Compression { get; init; }
 
+    /// <summary>
+    /// The time window to track duplicate messages for
+    /// </summary>
+    public TimeSpan? DuplicateWindow { get; init; } = null;
+
     // TODO: Bucket mirror configuration.
     // pub mirror: Option<Source>,
     // Bucket sources configuration.

--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -108,7 +108,7 @@ public class NatsKVContext : INatsKVContext
             // MirrorDirect =
             // Mirror =
             Retention = StreamConfigRetention.Limits, // from ADR-8
-            DuplicateWindow = TimeSpan.FromMinutes(2), // 120_000_000_000ns, from ADR-8
+            DuplicateWindow = config.DuplicateWindow ?? TimeSpan.FromMinutes(2), // 120_000_000_000ns, from ADR-8
         };
 
         var stream = await _context.CreateStreamAsync(streamConfig, cancellationToken);


### PR DESCRIPTION
The DuplicateWindow TimeSpan needs to be exposed for KVStores in order to facilitate certain patterns like leader election within a reasonable time period.  Currently it's fixed at 2 minutes, so you can't reduce MaxAge to less than this.

This PR just exposes DuplicateWindow via NatsKVConfig as an optional parameter with the default left at the current 2 minutes.