### PR TITLE
Added source generated helper method for registering service endpoints.

### DIFF
--- a/src/NATS.Client.Services.EndpointGenerator/NATS.Client.Services.EndpointGenerator.csproj
+++ b/src/NATS.Client.Services.EndpointGenerator/NATS.Client.Services.EndpointGenerator.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsTrimmable>true</IsTrimmable>
+    <EnforceExtendedAnalzerRules>true</EnforceExtendedAnalzerRules>
+    <!-- NuGet Packaging -->
+    <PackageTags>pubsub;messaging;microservices;services</PackageTags>
+    <Description>Attribute based registrations for Service API support for NATS.Client.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NATS.Client.Core\NATS.Client.Core.csproj" />
+    <ProjectReference Include="..\NATS.Client.Services\NATS.Client.Services.csproj" />
+    <InternalsVisibleTo Include="$(AssemblyName).Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd" />
+    <InternalsVisibleTo Include="NATS.Client.CheckNativeAot, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/NATS.Client.Services.EndpointGenerator/NatsSvcServerExtensions.cs
+++ b/src/NATS.Client.Services.EndpointGenerator/NatsSvcServerExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace NATS.Client.Services.EndpointGenerator;
+
+public static partial class NatsSvcServerExtensions
+{
+    public static async Task RegisterEndpointsAsync(this INatsSvcServer service, CancellationToken cancellationToken = default)
+    {
+    }
+
+}

--- a/src/NATS.Client.Services.EndpointGenerator/ServiceEndpointAttribute.cs
+++ b/src/NATS.Client.Services.EndpointGenerator/ServiceEndpointAttribute.cs
@@ -1,0 +1,8 @@
+namespace NATS.Client.Services.EndpointGenerator;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class ServiceEndpointAttribute(string name, string? queueGroup = null) : Attribute
+{
+    public string Name { get; } = name;
+    public string? QueueGroup { get; } = queueGroup;
+}

--- a/src/NATS.Client.Services.EndpointGenerator/ServiceEndpointGenerator.cs
+++ b/src/NATS.Client.Services.EndpointGenerator/ServiceEndpointGenerator.cs
@@ -1,0 +1,68 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace NATS.Client.Services.EndpointGenerator;
+
+[Generator]
+public class ServiceEndpointGenerator : ISourceGenerator
+{
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        // No initialization needed
+    }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        var compilation = context.Compilation;
+        var symbolsWithEndpointAttribute = GetSymbolsWithEndpointAttribute(compilation);
+
+        if (symbolsWithEndpointAttribute.Any())
+        {
+            var source = GenerateRegistrationCode(symbolsWithEndpointAttribute);
+            context.AddSource("NatsSvcExtensions.g.cs", source);
+        }
+    }
+
+    private static IEnumerable<IMethodSymbol> GetSymbolsWithEndpointAttribute(Compilation compilation)
+    {
+        var endpointAttributeSymbol = compilation.GetTypeByMetadataName("ServiceEndpointAttribute");
+        var methodSymbols = compilation.SyntaxTrees
+            .SelectMany(st => st.GetRoot().DescendantNodes())
+            .OfType<MethodDeclarationSyntax>()
+            .Select(mds => compilation.GetSemanticModel(mds.SyntaxTree).GetDeclaredSymbol(mds))
+            .OfType<IMethodSymbol>()
+            .Where(ms => ms.GetAttributes().Any(a => a.AttributeClass != null && a.AttributeClass.Equals(endpointAttributeSymbol, SymbolEqualityComparer.Default)));
+
+        return methodSymbols;
+    }
+
+    private static string GenerateRegistrationCode(IEnumerable<IMethodSymbol> methodSymbols)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("public static partial class NatsSvcServerExtensions");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static async Task RegisterEndpointsAsync(this INatsSvcServer service, CancellationToken cancellationToken = default)");
+        sb.AppendLine("    {");
+
+        foreach (var methodSymbol in methodSymbols)
+        {
+            var endpointAttribute = methodSymbol.GetAttributes().FirstOrDefault(a => a.AttributeClass.Name == "ServiceEndpointAttribute");
+            if (endpointAttribute != null)
+            {
+                var endpointName = (string)endpointAttribute.ConstructorArguments[0].Value;
+                var queueGroup = endpointAttribute.ConstructorArguments.Length > 1 ? (string)endpointAttribute.ConstructorArguments[1].Value : null;
+
+                var className = methodSymbol.ContainingType.Name;
+                var methodName = methodSymbol.Name;
+
+                sb.AppendLine($"        await service.AddEndpointAsync<{methodSymbol.ReturnType}>({className}.{methodName}, name: \"{endpointName}\", queueGroup: {(queueGroup != null ? $"\"{queueGroup}\"" : "null")}, cancellationToken: cancellationToken);");
+            }
+        }
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+}

--- a/tests/NATS.Client.Services.Tests/NATS.Client.Services.Tests.csproj
+++ b/tests/NATS.Client.Services.Tests/NATS.Client.Services.Tests.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NATS.Client.Serializers.Json\NATS.Client.Serializers.Json.csproj" />
+    <ProjectReference Include="..\..\src\NATS.Client.Services.EndpointGenerator\NATS.Client.Services.EndpointGenerator.csproj" />
     <ProjectReference Include="..\..\src\NATS.Client.Services\NATS.Client.Services.csproj" />
     <ProjectReference Include="..\NATS.Client.TestUtilities\NATS.Client.TestUtilities.csproj" />
   </ItemGroup>


### PR DESCRIPTION
I have outlined a method for Attribute based registration of Service Endpoints. 

This is done via a source generated extension method:

```
Task RegisterEndpointsAsync(this INatsSvcServer service, CancellationToken cancellationToken = default)
```

Methods are designated with the attribute `ServiceEndpoint`

Example:
```
 public class MyService
 {
     [ServiceEndpoint(name:"e1", queueGroup:null )]
     public async ValueTask<int> Endpoint1(NatsSvcMsg<int> m, CancellationToken cancellationToken)
     {
         if (m.Data == 7)
         {
             await m.ReplyErrorAsync(m.Data, $"Error{m.Data}", cancellationToken: cancellationToken);
             return 0;
         }

         if (m.Data == 8)
         {
             throw new NatsSvcEndpointException(m.Data, $"Error{m.Data}");
         }

         if (m.Data == 9)
         {
             throw new Exception("this won't be exposed");
         }

         await m.ReplyAsync(m.Data * m.Data, cancellationToken: cancellationToken);
         return m.Data * m.Data;
     }
 }
 ```
 
 Then the extension method is called on the created service.
 
Example:
```
  await using var s1 = await svc.AddServiceAsync("s1", "1.0.0", cancellationToken: cancellationToken);

  await s1.RegisterEndpointsAsync(cancellationToken);
  ```
  
  I was unable to get the source generated code to work with XUnit, however the code is very simple and straightforward. 
  
  
