### PR TITLE
Make Build() on NatsBuilder Internal

### DIFF
--- a/sandbox/MinimumWebApp/MinimumWebApp.csproj
+++ b/sandbox/MinimumWebApp/MinimumWebApp.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NATS.Client.Hosting\NATS.Client.Hosting.csproj" />
     <ProjectReference Include="..\..\src\NATS.Client.Core\NATS.Client.Core.csproj" />
+    <ProjectReference Include="..\..\src\NATS.Extensions.Microsoft.DependencyInjection\NATS.Extensions.Microsoft.DependencyInjection.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sandbox/MinimumWebApp/Program.cs
+++ b/sandbox/MinimumWebApp/Program.cs
@@ -1,10 +1,10 @@
 using NATS.Client.Core;
-using NATS.Client.Hosting;
+using NATS.Extensions.Microsoft.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Register NatsConnectionPool, NatsConnection, INatsCommand to ServiceCollection
-builder.Services.AddNats();
+// Register NatsConnectionPool, NatsConnection to ServiceCollection
+builder.Services.AddNatsClient();
 
 var app = builder.Build();
 

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
@@ -61,7 +61,7 @@ public class NatsBuilder
     }
 #endif
 
-    public IServiceCollection Build()
+    internal IServiceCollection Build()
     {
         if (_poolSize != 1)
         {


### PR DESCRIPTION
When swapping my code over to use the new hosting extensions I found what appears to be blunder of mine on the visibility of the `Build()` method. In order to prevent confusion for consumers thinking they need to call this method, I think hiding it would be best.

```cs
services.AddNatsClient(
    nats =>
    {
        nats.ConfigureOptions(ops => ops with { Url = config.Url });
        nats.Build(); // oops, this could cause confusion
    });
```