### PR TITLE
Resolves #476 - watch multiple kv filters

### DIFF
--- a/src/NATS.Client.KeyValueStore/INatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/INatsKVStore.cs
@@ -72,7 +72,7 @@ public interface INatsKVStore
     ValueTask<NatsKVEntry<T>> GetEntryAsync<T>(string key, ulong revision = default, INatsDeserialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Start a watcher for specific keys
+    /// Start a watcher for a specific key
     /// </summary>
     /// <param name="key">Key to watch (subject-based wildcards may be used)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
@@ -81,6 +81,17 @@ public interface INatsKVStore
     /// <typeparam name="T">Serialized value type</typeparam>
     /// <returns>An asynchronous enumerable which can be used in <c>await foreach</c> loops</returns>
     IAsyncEnumerable<NatsKVEntry<T>> WatchAsync<T>(string key, INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Start a watcher for specific keys
+    /// </summary>
+    /// <param name="keys">Keys to watch (subject-based wildcards may be used)</param>
+    /// <param name="serializer">Serializer to use for the message type.</param>
+    /// <param name="opts">Watch options</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <typeparam name="T">Serialized value type</typeparam>
+    /// <returns>An asynchronous enumerable which can be used in <c>await foreach</c> loops</returns>
+    IAsyncEnumerable<NatsKVEntry<T>> WatchAsync<T>(IList<string> keys, INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Start a watcher for all the keys in the bucket

--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -116,6 +116,7 @@ public class NatsKVStore : INatsKVStore
         }
     }
 
+    /// <inheritdoc />
     public async ValueTask DeleteAsync(string key, NatsKVDeleteOpts? opts = default, CancellationToken cancellationToken = default)
     {
         ValidateKey(key);
@@ -159,16 +160,7 @@ public class NatsKVStore : INatsKVStore
     public ValueTask PurgeAsync(string key, NatsKVDeleteOpts? opts = default, CancellationToken cancellationToken = default) =>
         DeleteAsync(key, (opts ?? new NatsKVDeleteOpts()) with { Purge = true }, cancellationToken);
 
-    /// <summary>
-    /// Get an entry from the bucket using the key
-    /// </summary>
-    /// <param name="key">Key of the entry</param>
-    /// <param name="revision">Revision to retrieve</param>
-    /// <param name="serializer">Optional serialized to override the default</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
-    /// <typeparam name="T">Serialized value type</typeparam>
-    /// <returns>The entry</returns>
-    /// <exception cref="NatsKVException">There was an error with metadata</exception>
+    /// <inheritdoc />
     public async ValueTask<NatsKVEntry<T>> GetEntryAsync<T>(string key, ulong revision = default, INatsDeserialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         ValidateKey(key);
@@ -322,18 +314,14 @@ public class NatsKVStore : INatsKVStore
         }
     }
 
-    /// <summary>
-    /// Start a watcher for specific keys
-    /// </summary>
-    /// <param name="key">Key to watch (subject-based wildcards may be used)</param>
-    /// <param name="serializer">Serializer to use for the message type.</param>
-    /// <param name="opts">Watch options</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
-    /// <typeparam name="T">Serialized value type</typeparam>
-    /// <returns>An asynchronous enumerable which can be used in <c>await foreach</c> loops</returns>
-    public async IAsyncEnumerable<NatsKVEntry<T>> WatchAsync<T>(string key, INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public IAsyncEnumerable<NatsKVEntry<T>> WatchAsync<T>(string key, INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, CancellationToken cancellationToken = default)
+        => WatchAsync<T>([key], serializer, opts, cancellationToken);
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<NatsKVEntry<T>> WatchAsync<T>(IList<string> keys, INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await using var watcher = await WatchInternalAsync<T>(key, serializer, opts, cancellationToken);
+        await using var watcher = await WatchInternalAsync<T>(keys, serializer, opts, cancellationToken);
 
         if (watcher.InitialConsumer.Info.NumPending == 0 && opts?.OnNoData != null)
         {
@@ -369,7 +357,7 @@ public class NatsKVStore : INatsKVStore
         opts ??= NatsKVWatchOpts.Default;
         opts = opts with { IncludeHistory = true };
 
-        await using var watcher = await WatchInternalAsync<T>(key, serializer, opts, cancellationToken);
+        await using var watcher = await WatchInternalAsync<T>([key], serializer, opts, cancellationToken);
 
         while (await watcher.Entries.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -382,6 +370,7 @@ public class NatsKVStore : INatsKVStore
         }
     }
 
+    /// <inheritdoc />
     public async ValueTask<NatsKVStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
         await _stream.RefreshAsync(cancellationToken);
@@ -389,16 +378,9 @@ public class NatsKVStore : INatsKVStore
         return new NatsKVStatus(Bucket, isCompressed, _stream.Info);
     }
 
-    /// <summary>
-    /// Start a watcher for all the keys in the bucket
-    /// </summary>
-    /// <param name="serializer">Serializer to use for the message type.</param>
-    /// <param name="opts">Watch options</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
-    /// <typeparam name="T">Serialized value type</typeparam>
-    /// <returns>An asynchronous enumerable which can be used in <c>await foreach</c> loops</returns>
+    /// <inheritdoc />
     public IAsyncEnumerable<NatsKVEntry<T>> WatchAsync<T>(INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, CancellationToken cancellationToken = default) =>
-        WatchAsync<T>(">", serializer, opts, cancellationToken);
+        WatchAsync<T>([">"], serializer, opts, cancellationToken);
 
     public async ValueTask PurgeDeletesAsync(NatsKVPurgeOpts? opts = default, CancellationToken cancellationToken = default)
     {
@@ -411,7 +393,7 @@ public class NatsKVStore : INatsKVStore
         var deleted = new List<NatsKVEntry<int>>();
 
         // Type doesn't matter here, we're just using the watcher to get the keys
-        await using (var watcher = await WatchInternalAsync<int>(">", opts: new NatsKVWatchOpts { MetaOnly = true }, cancellationToken: cancellationToken))
+        await using (var watcher = await WatchInternalAsync<int>([">"], opts: new NatsKVWatchOpts { MetaOnly = true }, cancellationToken: cancellationToken))
         {
             while (await watcher.Entries.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -444,19 +426,15 @@ public class NatsKVStore : INatsKVStore
         }
     }
 
+    /// <inheritdoc />
     public async IAsyncEnumerable<string> GetKeysAsync(NatsKVWatchOpts? opts = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         opts ??= NatsKVWatchOpts.Default;
 
-        opts = opts with
-        {
-            IgnoreDeletes = false,
-            MetaOnly = true,
-            UpdatesOnly = false,
-        };
+        opts = opts with { IgnoreDeletes = false, MetaOnly = true, UpdatesOnly = false, };
 
         // Type doesn't matter here, we're just using the watcher to get the keys
-        await using var watcher = await WatchInternalAsync<int>(">", serializer: default, opts, cancellationToken);
+        await using var watcher = await WatchInternalAsync<int>([">"], serializer: default, opts, cancellationToken);
 
         if (watcher.InitialConsumer.Info.NumPending == 0)
             yield break;
@@ -473,7 +451,7 @@ public class NatsKVStore : INatsKVStore
         }
     }
 
-    internal async ValueTask<NatsKVWatcher<T>> WatchInternalAsync<T>(string key, INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, CancellationToken cancellationToken = default)
+    internal async ValueTask<NatsKVWatcher<T>> WatchInternalAsync<T>(IList<string> keys, INatsDeserialize<T>? serializer = default, NatsKVWatchOpts? opts = default, CancellationToken cancellationToken = default)
     {
         opts ??= NatsKVWatchOpts.Default;
         serializer ??= _context.Connection.Opts.SerializerRegistry.GetDeserializer<T>();
@@ -481,7 +459,7 @@ public class NatsKVStore : INatsKVStore
         var watcher = new NatsKVWatcher<T>(
             context: _context,
             bucket: Bucket,
-            key: key,
+            keys: keys,
             opts: opts,
             serializer: serializer,
             subOpts: default,


### PR DESCRIPTION
Resolves #476 

> KV watch supports only single filter, which has limitations similar to those of single filter consumers.
> 
> Clients should support kv::watch watching multiple filters, leveraging consumers with multiple filters.
> 
> That can be a separate method (for example watch_many), or extension to the current one, depending on the language and it's ability to introduce multiple KV watch filters without breaking changes.

Would love for someone to do a more comprehensive safety check. I'm venturing into bits of the client that I haven't used yet. I looked at the v1 implementation and [this comment](https://github.com/nats-io/nats.net/pull/887/files/9ad54302c8a442a54eb8fac5e65138dbcca3e18a#r1559883388) had me scratching my head. It didn't seem to affect the tests I ran. So I assume this is handled differently in v2.