### PR TITLE
Fix NUID sequence

### DIFF
--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -63,8 +63,10 @@ internal sealed class NuidWriter
         // NOTE: We must never write to digitsPtr!
         ref var digitsPtr = ref MemoryMarshal.GetReference(Digits);
 
-        for (nuint i = PrefixLength; i < NuidLength; i++)
+        // write backwards so the last two characters change the fastest
+        for (nuint i = NuidLength; i > PrefixLength;)
         {
+            i--;
             var digitIndex = (nuint)(sequential % Base);
             Unsafe.Add(ref buffer[0], i) = Unsafe.Add(ref digitsPtr, digitIndex);
             sequential /= Base;

--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -64,7 +64,7 @@ internal sealed class NuidWriter
         ref var digitsPtr = ref MemoryMarshal.GetReference(Digits);
 
         // write backwards so the last two characters change the fastest
-        for (nuint i = NuidLength; i > PrefixLength;)
+        for (var i = NuidLength; i > PrefixLength;)
         {
             i--;
             var digitIndex = (nuint)(sequential % Base);


### PR DESCRIPTION
Fixed nuid sequence so the last few digits change similar to Go reference implementation.

there is also a report that Service ids aren't being generated uniquely which relies on NUIDs. I was not able to reproduce this but reminded me an old test fix I made (` DifferentThreads_DifferentPrefixes()` which is now reverted) which was failing intermittently due to id clashes.

cc @jasper-d 