### PR TITLE
FIX : PurgeDeletesAsync hangs if KV Bucket is already empty

### DIFF
--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -413,6 +413,9 @@ public class NatsKVStore : INatsKVStore
         // Type doesn't matter here, we're just using the watcher to get the keys
         await using (var watcher = await WatchInternalAsync<int>(">", opts: new NatsKVWatchOpts { MetaOnly = true }, cancellationToken: cancellationToken))
         {
+            if (watcher.InitialConsumer.Info.NumPending == 0)
+                return;
+
             while (await watcher.Entries.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 while (watcher.Entries.TryRead(out var entry))

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
@@ -364,6 +364,9 @@ public class KeyValueStoreTest
 
         _output.WriteLine($"COUNT={count}");
         Assert.Equal(0, count);
+
+        _output.WriteLine("PURGE ALL DELETES ON EMPTY BUCKET");
+        await store.PurgeDeletesAsync(opts: new NatsKVPurgeOpts { DeleteMarkersThreshold = TimeSpan.Zero }, cancellationToken: cancellationToken);
     }
 
     [Fact]


### PR DESCRIPTION
NatsKVStore.PurgeDeletesAsync hangs if KV Bucket is already empty.

Also updated Purge_deletes test