### PR TITLE
Change ConsumerConfig AckPolicy default to Explicit

### DIFF
--- a/sandbox/Example.JetStream.PullConsumer/Program.cs
+++ b/sandbox/Example.JetStream.PullConsumer/Program.cs
@@ -19,7 +19,7 @@ await using var nats = new NatsConnection(options);
 
 var js = new NatsJSContext(nats);
 
-var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1", AckPolicy = ConsumerConfigAckPolicy.Explicit });
+var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1" });
 
 var idle = TimeSpan.FromSeconds(5);
 var expires = TimeSpan.FromSeconds(10);

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -29,7 +29,6 @@ public record ConsumerConfig
     {
         Name = name;
         DurableName = name;
-        AckPolicy = ConsumerConfigAckPolicy.Explicit;
     }
 
     [System.Text.Json.Serialization.JsonPropertyName("deliver_policy")]

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -90,7 +90,7 @@ public record ConsumerConfig
 #if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigAckPolicy>))]
 #endif
-    public ConsumerConfigAckPolicy AckPolicy { get; set; } = ConsumerConfigAckPolicy.None;
+    public ConsumerConfigAckPolicy AckPolicy { get; set; } = ConsumerConfigAckPolicy.Explicit;
 
     /// <summary>
     /// How long (in nanoseconds) to allow messages to remain un-acknowledged before attempting redelivery

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -9,12 +9,10 @@ public record ConsumerConfig
     /// </summary>
     /// <remarks>
     /// When <c>DurableName</c> is not specified, the consumer is ephemeral.
-    /// This default constructor doesn't set any properties explicitly,
-    /// other than the default <c>AckPolicy</c> of <c>Explicit</c>.
+    /// This default constructor doesn't set any properties explicitly.
     /// </remarks>
     public ConsumerConfig()
     {
-        AckPolicy = ConsumerConfigAckPolicy.Explicit;
     }
 
     /// <summary>

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -9,10 +9,12 @@ public record ConsumerConfig
     /// </summary>
     /// <remarks>
     /// When <c>DurableName</c> is not specified, the consumer is ephemeral.
-    /// This default constructor doesn't set any properties explicitly.
+    /// This default constructor doesn't set any properties explicitly,
+    /// other than the default <c>AckPolicy</c> of <c>Explicit</c>.
     /// </remarks>
     public ConsumerConfig()
     {
+        AckPolicy = ConsumerConfigAckPolicy.Explicit;
     }
 
     /// <summary>

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
@@ -2,7 +2,7 @@ namespace NATS.Client.JetStream.Models;
 
 public enum ConsumerConfigAckPolicy
 {
-    None = 0,
+    Explicit = 0,
     All = 1,
-    Explicit = 2,
+    None = 2,
 }

--- a/tests/NATS.Client.CheckNativeAot/Program.cs
+++ b/tests/NATS.Client.CheckNativeAot/Program.cs
@@ -86,9 +86,6 @@ async Task JetStreamTests()
             {
                 Name = "consumer1",
                 DurableName = "consumer1",
-
-                // Turn on ACK so we can test them below
-                AckPolicy = ConsumerConfigAckPolicy.Explicit,
             },
             cts1.Token);
         AssertEqual("events", consumer.Info.StreamName);

--- a/tests/NATS.Client.Core.MemoryTests/NatsConsumeTests.cs
+++ b/tests/NATS.Client.Core.MemoryTests/NatsConsumeTests.cs
@@ -29,7 +29,7 @@ public class NatsConsumeTests
             {
                 await js.CreateStreamAsync(new StreamConfig { Name = "s1", Subjects = new[] { "s1.*" } });
 
-                var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1", AckPolicy = ConsumerConfigAckPolicy.Explicit });
+                var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig { Name = "c1", DurableName = "c1" });
 
                 var count = 0;
                 await foreach (var msg in consumer.ConsumeAsync<int>(opts: new NatsJSConsumeOpts { MaxMsgs = 100 }))

--- a/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
@@ -76,9 +76,6 @@ public class JetStreamTest
                 {
                     Name = "consumer1",
                     DurableName = "consumer1",
-
-                    // Turn on ACK so we can test them below
-                    AckPolicy = ConsumerConfigAckPolicy.Explicit,
                 },
                 cts1.Token);
             Assert.Equal("events", consumer.Info.StreamName);

--- a/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
@@ -148,7 +148,7 @@ public class ManageConsumerTest
         // Update consumer
         {
             var c1 = await js.GetConsumerAsync("s1", "c1");
-            Assert.Equal(default, c1.Info.Config.AckWait);
+            Assert.Equal(TimeSpan.FromSeconds(30), c1.Info.Config.AckWait);
 
             var changedConsumerConfig = new ConsumerConfig { Name = "c1", AckWait = TimeSpan.FromSeconds(10) };
             await js.UpdateConsumerAsync("s1", changedConsumerConfig);

--- a/tests/NATS.Client.JetStream.Tests/ParseJsonTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/ParseJsonTests.cs
@@ -25,4 +25,16 @@ public class ParseJsonTests
         Assert.Null(result.Cluster);
         Assert.Null(result.Tags);
     }
+
+    [Fact]
+    public void Default_consumer_ack_policy_should_be_explicit()
+    {
+        var serializer = NatsJSJsonSerializer<ConsumerConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new ConsumerConfig());
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan);
+        Assert.Matches("\"ack_policy\":\"explicit\"", json);
+    }
 }

--- a/tests/NATS.Net.DocsExamples/JetStream/ManagingPage.cs
+++ b/tests/NATS.Net.DocsExamples/JetStream/ManagingPage.cs
@@ -70,7 +70,6 @@ public class ManagingPage
             {
                 Name = "durable_processor",
                 DurableName = "durable_processor",
-                AckPolicy = ConsumerConfigAckPolicy.Explicit,
             };
 
             var consumer = await js.CreateOrUpdateConsumerAsync(stream: "orders", durableConfig);


### PR DESCRIPTION
Currently the no-args constructor for `ConsumerConfig` does not set the `AckPolicy` for the consumer, which defaults it to `None`. This is confusing given that the NATS docs state that the default `AckPolicy` is `Explicit`:
https://docs.nats.io/nats-concepts/jetstream/consumers#ackpolicy

This has led to unexpected behaviors since we had expected this to be set to `Explicit` by default for all consumers.

This PR changes the no-args `ConsumerConfig` constructor to set the `AckPolicy` to `Explicit`, to be the same as the constructor with a durable name.
