### PR TITLE
[PROPOSAL] Add overload for empty requests

### DIFF
--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -131,7 +131,7 @@ public interface INatsConnection : IAsyncDisposable
     /// <remarks>
     /// Response can be (null) or one <see cref="NatsMsg{T}"/>.
     /// Reply option's max messages will be set to 1.
-    /// if reply option's timeout is not defined then it will be set to NatsOpts.RequestTimeout.
+    /// If reply option's timeout is not defined, then it will be set to NatsOpts.RequestTimeout.
     /// </remarks>
     ValueTask<NatsMsg<TReply>> RequestAsync<TRequest, TReply>(
         string subject,
@@ -140,6 +140,27 @@ public interface INatsConnection : IAsyncDisposable
         INatsSerialize<TRequest>? requestSerializer = default,
         INatsDeserialize<TReply>? replySerializer = default,
         NatsPubOpts? requestOpts = default,
+        NatsSubOpts? replyOpts = default,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Send an empty request message and await the reply message asynchronously.
+    /// </summary>
+    /// <param name="subject">Subject of the responder</param>
+    /// <param name="replySerializer">Serializer to use for the reply message type.</param>
+    /// <param name="replyOpts">Reply handler subscription options</param>
+    /// <param name="cancellationToken">Cancel this request</param>
+    /// <typeparam name="TReply">Reply type</typeparam>
+    /// <returns>Returns the <see cref="NatsMsg{T}"/> received from the responder as reply.</returns>
+    /// <exception cref="OperationCanceledException">Raised when cancellation token is used</exception>
+    /// <remarks>
+    /// Response can be (null) or one <see cref="NatsMsg{T}"/>.
+    /// Reply option's max messages will be set to 1.
+    /// If reply option's timeout is not defined, then it will be set to NatsOpts.RequestTimeout.
+    /// </remarks>
+    ValueTask<NatsMsg<TReply>> RequestAsync<TReply>(
+        string subject,
+        INatsDeserialize<TReply>? replySerializer = default,
         NatsSubOpts? replyOpts = default,
         CancellationToken cancellationToken = default);
 

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -75,6 +75,22 @@ public partial class NatsConnection
     }
 
     /// <inheritdoc />
+    public ValueTask<NatsMsg<TReply>> RequestAsync<TReply>(
+        string subject,
+        INatsDeserialize<TReply>? replySerializer = default,
+        NatsSubOpts? replyOpts = default,
+        CancellationToken cancellationToken = default) =>
+        RequestAsync<object, TReply>(
+            subject: subject,
+            data: default,
+            headers: default,
+            requestSerializer: default,
+            replySerializer: replySerializer,
+            requestOpts: default,
+            replyOpts: replyOpts,
+            cancellationToken: cancellationToken);
+
+    /// <inheritdoc />
     public async IAsyncEnumerable<NatsMsg<TReply>> RequestManyAsync<TRequest, TReply>(
         string subject,
         TRequest? data,

--- a/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
@@ -392,4 +392,28 @@ public class RequestReplyTest
         await sub.DisposeAsync();
         await reg;
     }
+
+    [Fact]
+    public async Task Simple_empty_request_reply_test()
+    {
+        await using var server = NatsServer.Start();
+        await using var nats = server.CreateClientConnection();
+
+        const string subject = "foo";
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        var sub = await nats.SubscribeCoreAsync<int>(subject, cancellationToken: cancellationToken);
+        var reg = sub.Register(async msg =>
+        {
+            await msg.ReplyAsync(42, cancellationToken: cancellationToken);
+        });
+
+        var rep = await nats.RequestAsync<int>(subject, cancellationToken: cancellationToken);
+
+        Assert.Equal(42, rep.Data);
+
+        await sub.DisposeAsync();
+        await reg;
+    }
 }

--- a/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core.Tests/RequestReplyTest.cs
@@ -409,9 +409,11 @@ public class RequestReplyTest
             await msg.ReplyAsync(42, cancellationToken: cancellationToken);
         });
 
-        var rep = await nats.RequestAsync<int>(subject, cancellationToken: cancellationToken);
+        var reply1 = await nats.RequestAsync<object, int>(subject, null, cancellationToken: cancellationToken);
+        var reply2 = await nats.RequestAsync<int>(subject, cancellationToken: cancellationToken);
 
-        Assert.Equal(42, rep.Data);
+        Assert.Equal(42, reply1.Data);
+        Assert.Equal(42, reply2.Data);
 
         await sub.DisposeAsync();
         await reg;

--- a/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
@@ -123,6 +123,8 @@ public class NatsJSContextFactoryTest
             CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
+        public ValueTask<NatsMsg<TReply>> RequestAsync<TReply>(string subject, INatsDeserialize<TReply>? replySerializer = default, NatsSubOpts? replyOpts = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
         public IAsyncEnumerable<NatsMsg<TReply>> RequestManyAsync<TRequest, TReply>(
             string subject,
             TRequest? data,


### PR DESCRIPTION
Proposing a convenience method where request payload isn't required in request-reply calls. It is fairly common to request data without sending any payload. With this method application code can avoid boilerplate null data parameter and request type parameter making the call much more succinct.

```csharp
// current way of sending an empty request payload
var reply1 = await nats.RequestAsync<object, int>(subject, data: null);

// proposed API. calls the method above
var reply2 = await nats.RequestAsync<int>(subject);
```
