### PR TITLE
Keep sub alive when reading channel

### DIFF
--- a/sandbox/MicroBenchmark/PublishParallelBench.cs
+++ b/sandbox/MicroBenchmark/PublishParallelBench.cs
@@ -45,6 +45,9 @@ public class PublishParallelBench
         await _nats.ConnectAsync();
     }
 
+    [GlobalCleanup]
+    public async Task Cleanup() => await _nats.DisposeAsync();
+
     [Benchmark]
     public async Task PublishParallelAsync()
     {

--- a/sandbox/MicroBenchmark/PublishSerialBench.cs
+++ b/sandbox/MicroBenchmark/PublishSerialBench.cs
@@ -23,6 +23,9 @@ public class PublishSerialBench
         await _nats.ConnectAsync();
     }
 
+    [GlobalCleanup]
+    public async Task Cleanup() => await _nats.DisposeAsync();
+
     [Benchmark]
     public async Task PublishAsync()
     {

--- a/sandbox/MicroBenchmark/Subscribe.cs
+++ b/sandbox/MicroBenchmark/Subscribe.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using NATS.Client.Core;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+namespace MicroBenchmark;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[PlainExporter]
+public class Subscribe
+{
+    private const int TotalMsgs = 500_000;
+    private NatsConnection _nats;
+    private CancellationTokenSource _cts;
+    private Task _pubTask;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _nats = new NatsConnection(NatsOpts.Default);
+        await _nats.ConnectAsync();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _nats.DisposeAsync();
+
+    [IterationSetup]
+    public void IterSetup()
+    {
+        _cts = new CancellationTokenSource();
+        _pubTask = PubTask(_cts);
+    }
+
+    [IterationCleanup]
+    public void IterCleanup()
+    {
+        _cts.Cancel();
+        _pubTask.GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public async Task SubscribeAsync()
+    {
+        var count = 0;
+#pragma warning disable SA1312
+        await foreach (var _ in _nats.SubscribeAsync<string>("test"))
+#pragma warning restore SA1312
+        {
+            if (++count >= TotalMsgs)
+            {
+                return;
+            }
+        }
+    }
+
+    [Benchmark]
+    public async Task CoreWait()
+    {
+        var count = 0;
+        await using var sub = await _nats.SubscribeCoreAsync<string>("test");
+        while (await sub.Msgs.WaitToReadAsync())
+        {
+            while (sub.Msgs.TryRead(out _))
+            {
+                if (++count >= TotalMsgs)
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    [Benchmark]
+    public async Task CoreRead()
+    {
+        var count = 0;
+        await using var sub = await _nats.SubscribeCoreAsync<string>("test");
+        while (true)
+        {
+            await sub.Msgs.ReadAsync();
+            if (++count >= TotalMsgs)
+            {
+                return;
+            }
+        }
+    }
+
+    [Benchmark]
+    public async Task CoreReadAll()
+    {
+        var count = 0;
+        await using var sub = await _nats.SubscribeCoreAsync<string>("test");
+#pragma warning disable SA1312
+        await foreach (var _ in sub.Msgs.ReadAllAsync())
+#pragma warning restore SA1312
+        {
+            if (++count >= TotalMsgs)
+            {
+                return;
+            }
+        }
+    }
+
+    // limit pub to the same rate across benchmarks
+    // pub in batches so that groups of messages are available
+    private Task PubTask(CancellationTokenSource cts) =>
+        Task.Run(async () =>
+        {
+            const long pubMaxPerSecond = TotalMsgs;
+            const long batchSize = 100;
+            const long ticksBetweenBatches = TimeSpan.TicksPerSecond / pubMaxPerSecond * batchSize;
+
+            var sw = new Stopwatch();
+            sw.Start();
+            var lastTick = sw.ElapsedTicks;
+            var i = 0L;
+            while (!cts.IsCancellationRequested)
+            {
+                await _nats.PublishAsync("test", "data");
+                if (++i % batchSize == 0)
+                {
+                    while (sw.ElapsedTicks - lastTick < ticksBetweenBatches)
+                    {
+                    }
+
+                    lastTick = sw.ElapsedTicks;
+                }
+            }
+        });
+}

--- a/src/NATS.Client.Core/Internal/ActivityEndingMsgReader.cs
+++ b/src/NATS.Client.Core/Internal/ActivityEndingMsgReader.cs
@@ -1,21 +1,66 @@
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading.Channels;
 
 namespace NATS.Client.Core.Internal;
 
+// ActivityEndingMsgReader servers 2 purposes
+// 1. End activity for OpenTelemetry
+// 2. Keep the INatsSub<T> from being garbage collected as long as calls interacting
+//    with the _inner channel are being made
+// To achieve (1):
+// Calls that result in a read from the _inner channel should msg.Headers?.Activity?.Dispose()
+// To achieve (2):
+// Synchronous calls should call GC.KeepAlive(_sub); immediately before returning
+// Asynchronous calls should allocate a GCHandle.Alloc(_sub) at the start of the method,
+// and then free it in a try/finally block
 internal sealed class ActivityEndingMsgReader<T> : ChannelReader<NatsMsg<T>>
 {
     private readonly ChannelReader<NatsMsg<T>> _inner;
 
-    public ActivityEndingMsgReader(ChannelReader<NatsMsg<T>> inner) => _inner = inner;
+    private readonly INatsSub<T> _sub;
 
-    public override bool CanCount => _inner.CanCount;
+    public ActivityEndingMsgReader(ChannelReader<NatsMsg<T>> inner, INatsSub<T> sub)
+    {
+        _inner = inner;
+        _sub = sub;
+    }
 
-    public override bool CanPeek => _inner.CanPeek;
+    public override bool CanCount
+    {
+        get
+        {
+            GC.KeepAlive(_sub);
+            return _inner.CanCount;
+        }
+    }
 
-    public override int Count => _inner.Count;
+    public override bool CanPeek
+    {
+        get
+        {
+            GC.KeepAlive(_sub);
+            return _inner.CanPeek;
+        }
+    }
 
-    public override Task Completion => _inner.Completion;
+    public override int Count
+    {
+        get
+        {
+            GC.KeepAlive(_sub);
+            return _inner.Count;
+        }
+    }
+
+    public override Task Completion
+    {
+        get
+        {
+            GC.KeepAlive(_sub);
+            return _inner.Completion;
+        }
+    }
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -26,16 +71,61 @@ internal sealed class ActivityEndingMsgReader<T> : ChannelReader<NatsMsg<T>>
 
         item.Headers?.Activity?.Dispose();
 
+        GC.KeepAlive(_sub);
         return true;
     }
 
-    /// <inheritdoc/>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default) => _inner.WaitToReadAsync(cancellationToken);
+    public override async ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default)
+    {
+        var handle = GCHandle.Alloc(_sub);
+        try
+        {
+            return await _inner.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
 
-    public override ValueTask<NatsMsg<T>> ReadAsync(CancellationToken cancellationToken = default) => _inner.ReadAsync(cancellationToken);
+    public override async ValueTask<NatsMsg<T>> ReadAsync(CancellationToken cancellationToken = default)
+    {
+        var handle = GCHandle.Alloc(_sub);
+        try
+        {
+            var msg = await _inner.ReadAsync(cancellationToken).ConfigureAwait(false);
+            msg.Headers?.Activity?.Dispose();
+            return msg;
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
 
-    public override bool TryPeek(out NatsMsg<T> item) => _inner.TryPeek(out item);
+    public override bool TryPeek(out NatsMsg<T> item)
+    {
+        GC.KeepAlive(_sub);
+        return _inner.TryPeek(out item);
+    }
 
-    public override IAsyncEnumerable<NatsMsg<T>> ReadAllAsync(CancellationToken cancellationToken = default) => _inner.ReadAllAsync(cancellationToken);
+    public override async IAsyncEnumerable<NatsMsg<T>> ReadAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var handle = GCHandle.Alloc(_sub);
+        try
+        {
+            while (await _inner.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (_inner.TryRead(out var msg))
+                {
+                    msg.Headers?.Activity?.Dispose();
+                    yield return msg;
+                }
+            }
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
 }

--- a/src/NATS.Client.Core/NatsConnection.Subscribe.cs
+++ b/src/NATS.Client.Core/NatsConnection.Subscribe.cs
@@ -22,12 +22,9 @@ public partial class NatsConnection
 
         // We don't cancel the channel reader here because we want to keep reading until the subscription
         // channel writer completes so that messages left in the channel can be consumed before exit the loop.
-        while (await sub.Msgs.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
+        await foreach (var msg in sub.Msgs.ReadAllAsync(CancellationToken.None).ConfigureAwait(false))
         {
-            while (sub.Msgs.TryRead(out var msg))
-            {
-                yield return msg;
-            }
+            yield return msg;
         }
     }
 

--- a/src/NATS.Client.Core/NatsConnection.Subscribe.cs
+++ b/src/NATS.Client.Core/NatsConnection.Subscribe.cs
@@ -16,9 +16,8 @@ public partial class NatsConnection
     {
         serializer ??= Opts.SerializerRegistry.GetDeserializer<T>();
 
+        // call to RegisterSubAnchor is no longer needed; sub is kept alive in ActivityEndingMsgReader
         await using var sub = new NatsSub<T>(this, SubscriptionManager.GetManagerFor(subject), subject, queueGroup, opts, serializer, cancellationToken);
-        using var anchor = RegisterSubAnchor(sub);
-
         await SubAsync(sub, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         // We don't cancel the channel reader here because we want to keep reading until the subscription

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -23,7 +23,7 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
             connection.GetChannelOpts(connection.Opts, opts?.ChannelOpts),
             msg => Connection.OnMessageDropped(this, _msgs?.Reader.Count ?? 0, msg));
 
-        Msgs = new ActivityEndingMsgReader<T>(_msgs.Reader);
+        Msgs = new ActivityEndingMsgReader<T>(_msgs.Reader, this);
 
         Serializer = serializer;
     }

--- a/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
+++ b/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
@@ -38,130 +38,185 @@ public class NatsSubTests
         }
         finally
         {
-            server.DisposeAsync().GetAwaiter().GetResult();
+            server.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
     }
 
     [Test]
-    public void Subscription_should_not_be_collected_subscribe_async() =>
-        RunSubTest(async (nats, channelWriter, iterations) =>
-        {
-            var i = 0;
-#pragma warning disable SA1312
-            await foreach (var _ in nats.SubscribeAsync<string>("foo.*"))
-#pragma warning restore SA1312
-            {
-                await channelWriter.WriteAsync(new object());
-                if (++i >= iterations)
-                    break;
-            }
-        });
-
-    [Test]
-    public void Subscription_should_not_be_collected_subscribe_core_async_read_all_async() =>
-        RunSubTest(async (nats, channelWriter, iterations) =>
-        {
-            var i = 0;
-            await using var sub = await nats.SubscribeCoreAsync<string>("foo.*");
-#pragma warning disable SA1312
-            await foreach (var _ in sub.Msgs.ReadAllAsync())
-#pragma warning restore SA1312
-            {
-                await channelWriter.WriteAsync(new object());
-                if (++i >= iterations)
-                    break;
-            }
-        });
-
-    [Test]
-    public void Subscription_should_not_be_collected_subscribe_core_async_read_async() =>
-        RunSubTest(async (nats, channelWriter, iterations) =>
-        {
-            var i = 0;
-            await using var sub = await nats.SubscribeCoreAsync<string>("foo.*");
-            while (true)
-            {
-                await sub.Msgs.ReadAsync();
-                await channelWriter.WriteAsync(new object());
-                if (++i >= iterations)
-                    break;
-            }
-        });
-
-    [Test]
-    public void Subscription_should_not_be_collected_subscribe_core_async_wait_to_read_async() =>
-        RunSubTest(async (nats, channelWriter, iterations) =>
-        {
-            var i = 0;
-            await using var sub = await nats.SubscribeCoreAsync<string>("foo.*");
-            while (await sub.Msgs.WaitToReadAsync())
-            {
-                while (sub.Msgs.TryRead(out _))
-                {
-                    await channelWriter.WriteAsync(new object());
-                    i++;
-                }
-
-                if (i >= iterations)
-                {
-                    break;
-                }
-            }
-        });
-
-    private void RunSubTest(Func<NatsConnection, ChannelWriter<object>, int, Task> subTask)
+    public void Subscription_should_not_be_collected_subscribe_async()
     {
         var server = NatsServer.Start();
         try
         {
             const int iterations = 10;
+            const string subject = "foo.data";
             var nats = server.CreateClientConnection(new NatsOpts { RequestTimeout = TimeSpan.FromSeconds(10) });
             var received = Channel.CreateUnbounded<object>();
-            var task = subTask(nats, received.Writer, iterations);
 
-            var i = 0;
-            var fail = 0;
-            while (true)
+            var subTask = Task.Run(async () =>
             {
-                nats.PublishAsync("foo.data", "data").AsTask().GetAwaiter().GetResult();
-                try
+                var i = 0;
+#pragma warning disable SA1312
+                await foreach (var _ in nats.SubscribeAsync<string>(subject))
+#pragma warning restore SA1312
                 {
-                    using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-                    received.Reader.ReadAsync(cts.Token).AsTask().GetAwaiter().GetResult();
+                    await received.Writer.WriteAsync(new object());
+                    if (++i >= iterations)
+                        break;
                 }
-                catch (OperationCanceledException)
+            });
+
+            RunSubTest(iterations, subject, nats, received, subTask);
+        }
+        finally
+        {
+            server.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    [Test]
+    public void Subscription_should_not_be_collected_subscribe_core_async_read_all_async()
+    {
+        var server = NatsServer.Start();
+        try
+        {
+            const int iterations = 10;
+            const string subject = "foo.data";
+            var nats = server.CreateClientConnection(new NatsOpts { RequestTimeout = TimeSpan.FromSeconds(10) });
+            var received = Channel.CreateUnbounded<object>();
+
+            var subTask = Task.Run(async () =>
+            {
+                var i = 0;
+                await using var sub = await nats.SubscribeCoreAsync<string>(subject);
+#pragma warning disable SA1312
+                await foreach (var _ in sub.Msgs.ReadAllAsync())
+#pragma warning restore SA1312
                 {
-                    if (++fail <= 10)
+                    await received.Writer.WriteAsync(new object());
+                    if (++i >= iterations)
+                        break;
+                }
+            });
+
+            RunSubTest(iterations, subject, nats, received, subTask);
+        }
+        finally
+        {
+            server.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    [Test]
+    public void Subscription_should_not_be_collected_subscribe_core_async_read_async()
+    {
+        var server = NatsServer.Start();
+        try
+        {
+            const int iterations = 10;
+            const string subject = "foo.data";
+            var nats = server.CreateClientConnection(new NatsOpts { RequestTimeout = TimeSpan.FromSeconds(10) });
+            var received = Channel.CreateUnbounded<object>();
+
+            var subTask = Task.Run(async () =>
+            {
+                var i = 0;
+                await using var sub = await nats.SubscribeCoreAsync<string>(subject);
+                while (true)
+                {
+                    await sub.Msgs.ReadAsync();
+                    await received.Writer.WriteAsync(new object());
+                    if (++i >= iterations)
+                        break;
+                }
+            });
+
+            RunSubTest(iterations, subject, nats, received, subTask);
+        }
+        finally
+        {
+            server.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    [Test]
+    public void Subscription_should_not_be_collected_subscribe_core_async_wait_to_read_async()
+    {
+        var server = NatsServer.Start();
+        try
+        {
+            const int iterations = 10;
+            const string subject = "foo.data";
+            var nats = server.CreateClientConnection(new NatsOpts { RequestTimeout = TimeSpan.FromSeconds(10) });
+            var received = Channel.CreateUnbounded<object>();
+
+            var subTask = Task.Run(async () =>
+            {
+                var i = 0;
+                await using var sub = await nats.SubscribeCoreAsync<string>(subject);
+                while (await sub.Msgs.WaitToReadAsync())
+                {
+                    while (sub.Msgs.TryRead(out _))
                     {
-                        continue;
+                        await received.Writer.WriteAsync(new object());
+                        i++;
                     }
 
-                    Assert.Fail($"failed to receive a reply 10 times");
+                    if (i >= iterations)
+                    {
+                        break;
+                    }
+                }
+            });
+
+            RunSubTest(iterations, subject, nats, received, subTask);
+        }
+        finally
+        {
+            server.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    private void RunSubTest(int iterations, string subject, NatsConnection nats, Channel<object> received, Task subTask)
+    {
+        var i = 0;
+        var fail = 0;
+        while (true)
+        {
+            nats.PublishAsync(subject, "data").AsTask().GetAwaiter().GetResult();
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+                received.Reader.ReadAsync(cts.Token).AsTask().GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                if (++fail <= 10)
+                {
+                    continue;
                 }
 
-                if (++i >= iterations)
-                    break;
-
-                GC.Collect();
-                dotMemory.Check(memory =>
-                {
-                    var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
-                    Assert.That(count, Is.EqualTo(1), $"Alive - received {i}");
-                });
+                Assert.Fail($"failed to receive a reply 10 times");
             }
 
-            task.GetAwaiter().GetResult();
+            if (++i >= iterations)
+                break;
 
             GC.Collect();
             dotMemory.Check(memory =>
             {
                 var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
-                Assert.That(count, Is.EqualTo(0), "Collected");
+                Assert.That(count, Is.EqualTo(1), $"Alive - received {i}");
             });
         }
-        finally
+
+        subTask.GetAwaiter().GetResult();
+
+        GC.Collect();
+        dotMemory.Check(memory =>
         {
-            server.DisposeAsync().GetAwaiter().GetResult();
-        }
+            var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
+            Assert.That(count, Is.EqualTo(0), "Collected");
+        });
     }
 }

--- a/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
+++ b/tests/NATS.Client.Core.MemoryTests/NatsSubTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Channels;
 using JetBrains.dotMemoryUnit;
 using NATS.Client.Core.Tests;
 
@@ -42,66 +43,116 @@ public class NatsSubTests
     }
 
     [Test]
-    public void Subscription_should_not_be_collected_when_in_async_enumerator()
+    public void Subscription_should_not_be_collected_subscribe_async() =>
+        RunSubTest(async (nats, channelWriter, iterations) =>
+        {
+            var i = 0;
+#pragma warning disable SA1312
+            await foreach (var _ in nats.SubscribeAsync<string>("foo.*"))
+#pragma warning restore SA1312
+            {
+                await channelWriter.WriteAsync(new object());
+                if (++i >= iterations)
+                    break;
+            }
+        });
+
+    [Test]
+    public void Subscription_should_not_be_collected_subscribe_core_async_read_all_async() =>
+        RunSubTest(async (nats, channelWriter, iterations) =>
+        {
+            var i = 0;
+            await using var sub = await nats.SubscribeCoreAsync<string>("foo.*");
+#pragma warning disable SA1312
+            await foreach (var _ in sub.Msgs.ReadAllAsync())
+#pragma warning restore SA1312
+            {
+                await channelWriter.WriteAsync(new object());
+                if (++i >= iterations)
+                    break;
+            }
+        });
+
+    [Test]
+    public void Subscription_should_not_be_collected_subscribe_core_async_read_async() =>
+        RunSubTest(async (nats, channelWriter, iterations) =>
+        {
+            var i = 0;
+            await using var sub = await nats.SubscribeCoreAsync<string>("foo.*");
+            while (true)
+            {
+                await sub.Msgs.ReadAsync();
+                await channelWriter.WriteAsync(new object());
+                if (++i >= iterations)
+                    break;
+            }
+        });
+
+    [Test]
+    public void Subscription_should_not_be_collected_subscribe_core_async_wait_to_read_async() =>
+        RunSubTest(async (nats, channelWriter, iterations) =>
+        {
+            var i = 0;
+            await using var sub = await nats.SubscribeCoreAsync<string>("foo.*");
+            while (await sub.Msgs.WaitToReadAsync())
+            {
+                while (sub.Msgs.TryRead(out _))
+                {
+                    await channelWriter.WriteAsync(new object());
+                    i++;
+                }
+
+                if (i >= iterations)
+                {
+                    break;
+                }
+            }
+        });
+
+    private void RunSubTest(Func<NatsConnection, ChannelWriter<object>, int, Task> subTask)
     {
         var server = NatsServer.Start();
         try
         {
+            const int iterations = 10;
             var nats = server.CreateClientConnection(new NatsOpts { RequestTimeout = TimeSpan.FromSeconds(10) });
+            var received = Channel.CreateUnbounded<object>();
+            var task = subTask(nats, received.Writer, iterations);
 
-            var sync = 0;
-
-            var sub = Task.Run(async () =>
+            var i = 0;
+            var fail = 0;
+            while (true)
             {
-                var count = 0;
-                await foreach (var msg in nats.SubscribeAsync<string>("foo.*"))
+                nats.PublishAsync("foo.data", "data").AsTask().GetAwaiter().GetResult();
+                try
                 {
-                    if (msg.Subject == "foo.sync")
+                    using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+                    received.Reader.ReadAsync(cts.Token).AsTask().GetAwaiter().GetResult();
+                }
+                catch (OperationCanceledException)
+                {
+                    if (++fail <= 10)
                     {
-                        Interlocked.Increment(ref sync);
                         continue;
                     }
 
-                    if (++count == 10)
-                        break;
+                    Assert.Fail($"failed to receive a reply 10 times");
                 }
-            });
 
-            var pub = Task.Run(async () =>
-            {
-                while (Volatile.Read(ref sync) == 0)
+                if (++i >= iterations)
+                    break;
+
+                GC.Collect();
+                dotMemory.Check(memory =>
                 {
-                    await nats.PublishAsync("foo.sync", "sync");
-                }
-
-                for (var i = 0; i < 10; i++)
-                {
-                    GC.Collect();
-
-                    dotMemory.Check(memory =>
-                    {
-                        var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
-                        Assert.That(count, Is.EqualTo(1), "Alive");
-                    });
-
-                    await nats.PublishAsync("foo.data", "data");
-                }
-            });
-
-            var waitPub = Task.WaitAll(new[] { pub }, TimeSpan.FromSeconds(10));
-            if (!waitPub)
-            {
-                Assert.Fail("Timed out waiting for pub task to complete");
+                    var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;
+                    Assert.That(count, Is.EqualTo(1), $"Alive - received {i}");
+                });
             }
 
-            var waitSub = Task.WaitAll(new[] { sub }, TimeSpan.FromSeconds(10));
-            if (!waitSub)
-            {
-                Assert.Fail("Timed out waiting for sub task to complete");
-            }
+            task.GetAwaiter().GetResult();
 
             GC.Collect();
-
             dotMemory.Check(memory =>
             {
                 var count = memory.GetObjects(where => where.Type.Is<NatsSub<string>>()).ObjectsCount;


### PR DESCRIPTION
Resolves #499 
Resolves #505 

Adds GC keepalive calls to `ActivityEndingMsgReader` in order to prevent sub from being GC'd while the channel reader is being interacted with.

Learned about `GCHandle.Alloc` from this blog post - [Using GC.KeepAlive in async methods](https://minidump.net/c-using-gc-keepalive-in-async-methods-8d20fd79f0a0/)

I left `RegisterSubAnchor` in place for now as I saw it was in-use still in the JetStream project.  But if every sub there uses an `ActivityEndingMsgReader` it should be able to be eliminated.