### PR TITLE
Prefer sub channel ReadAllAsync and remove SubAnchor

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -42,12 +42,9 @@ public partial class NatsConnection
                 await using var sub1 = await RequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)
                     .ConfigureAwait(false);
 
-                if (await sub1.Msgs.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                await foreach (var msg in sub1.Msgs.ReadAllAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    if (sub1.Msgs.TryRead(out var msg))
-                    {
-                        return msg;
-                    }
+                    return msg;
                 }
 
                 throw new NatsNoReplyException();
@@ -63,12 +60,9 @@ public partial class NatsConnection
         await using var sub = await RequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)
             .ConfigureAwait(false);
 
-        if (await sub.Msgs.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        await foreach (var msg in sub.Msgs.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (sub.Msgs.TryRead(out var msg))
-            {
-                return msg;
-            }
+            return msg;
         }
 
         throw new NatsNoReplyException();
@@ -105,12 +99,9 @@ public partial class NatsConnection
         await using var sub = await RequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)
             .ConfigureAwait(false);
 
-        while (await sub.Msgs.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        await foreach (var msg in sub.Msgs.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
-            while (sub.Msgs.TryRead(out var msg))
-            {
-                yield return msg;
-            }
+            yield return msg;
         }
     }
 

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -62,9 +62,6 @@ public class NatsJSConsumer : INatsJSConsumer
         opts ??= _context.Opts.DefaultConsumeOpts;
         await using var cc = await ConsumeInternalAsync<T>(serializer, opts, cancellationToken).ConfigureAwait(false);
 
-        // Keep subscription alive (since it's a weak ref in subscription manager) until we're done.
-        using var anchor = _context.Connection.RegisterSubAnchor(cc);
-
         while (!cancellationToken.IsCancellationRequested)
         {
             // We have to check calls individually since we can't use yield return in try-catch blocks.
@@ -151,9 +148,6 @@ public class NatsJSConsumer : INatsJSConsumer
             serializer,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        // Keep subscription alive (since it's a weak ref in subscription manager) until we're done.
-        using var anchor = _context.Connection.RegisterSubAnchor(f);
-
         await foreach (var natsJSMsg in f.Msgs.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
             return natsJSMsg;
@@ -172,9 +166,6 @@ public class NatsJSConsumer : INatsJSConsumer
         serializer ??= _context.Connection.Opts.SerializerRegistry.GetDeserializer<T>();
 
         await using var fc = await FetchInternalAsync<T>(opts, serializer, cancellationToken).ConfigureAwait(false);
-
-        // Keep subscription alive (since it's a weak ref in subscription manager) until we're done.
-        using var anchor = _context.Connection.RegisterSubAnchor(fc);
 
         while (!cancellationToken.IsCancellationRequested)
         {

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -80,9 +80,6 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
 
                 await using (var cc = await consumer.OrderedConsumeInternalAsync(serializer, opts, cancellationToken))
                 {
-                    // Keep subscription alive (since it's a wek ref in subscription manager) until we're done.
-                    using var anchor = _context.Connection.RegisterSubAnchor(cc);
-
                     while (true)
                     {
                         // We have to check every call to WaitToReadAsync and TryRead for


### PR DESCRIPTION
Follow-up to #506

- Prefer using sub channel ReadAllAsync where it was easy to swap out based on benchmark: https://github.com/nats-io/nats.net.v2/pull/506#issuecomment-2148235951
- Remove remaining SubAnchor references since `ActivityEndingMsgReader` should now be keeping those subs alive