### PR TITLE
JetStream Concurrent Publish

### DIFF
--- a/sandbox/MicroBenchmark/JSPublishBench.cs
+++ b/sandbox/MicroBenchmark/JSPublishBench.cs
@@ -1,0 +1,66 @@
+using BenchmarkDotNet.Attributes;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+namespace MicroBenchmark;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[PlainExporter]
+public class JSPublishBench
+{
+    private NatsConnection _nats;
+    private NatsJSContext _js;
+
+    [Params(1, 10, 1_000)]
+    public int Batch { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _nats = new NatsConnection();
+        _js = new NatsJSContext(_nats);
+        await _nats.ConnectAsync();
+        await _js.CreateStreamAsync(new StreamConfig("bench_test1", ["bench_test1"]));
+        await _js.CreateStreamAsync(new StreamConfig("bench_test2", ["bench_test2"]));
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _js.DeleteStreamAsync("bench_test1");
+        await _js.DeleteStreamAsync("bench_test2");
+        await _nats.DisposeAsync();
+    }
+
+    [Benchmark]
+    public async Task PublishAsync()
+    {
+        for (var i = 0; i < Batch; i++)
+        {
+            var ack = await _js.PublishAsync("bench_test1", i);
+            ack.EnsureSuccess();
+        }
+    }
+
+    [Benchmark]
+    public async Task PublishConcurrentlyAsync()
+    {
+        var futures = new NatsJSPublishConcurrentFuture[Batch];
+
+        for (var i = 0; i < Batch; i++)
+        {
+            futures[i] = await _js.PublishConcurrentAsync("bench_test2", i);
+        }
+
+        for (var i = 0; i < Batch; i++)
+        {
+            await using var future = futures[i];
+            var ack = await future.GetResponseAsync();
+            ack.EnsureSuccess();
+        }
+    }
+}

--- a/sandbox/MicroBenchmark/MicroBenchmark.csproj
+++ b/sandbox/MicroBenchmark/MicroBenchmark.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\NATS.Client.Core\NATS.Client.Core.csproj" />
+        <ProjectReference Include="..\..\src\NATS.Client.JetStream\NATS.Client.JetStream.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/NATS.Client.JetStream/INatsJSContext.cs
+++ b/src/NATS.Client.JetStream/INatsJSContext.cs
@@ -283,4 +283,12 @@ public interface INatsJSContext
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <returns>Async enumerable list of stream names to be used in a <c>await foreach</c> loop.</returns>
     IAsyncEnumerable<string> ListStreamNamesAsync(string? subject = default, CancellationToken cancellationToken = default);
+
+    ValueTask<NatsJSPublishConcurrentFuture> PublishConcurrentAsync<T>(
+        string subject,
+        T? data,
+        INatsSerialize<T>? serializer = default,
+        NatsJSPubOpts? opts = default,
+        NatsHeaders? headers = default,
+        CancellationToken cancellationToken = default);
 }

--- a/src/NATS.Client.JetStream/Internal/NatsJSErrorAwareJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSErrorAwareJsonSerializer.cs
@@ -23,7 +23,7 @@ internal sealed class NatsJSErrorAwareJsonSerializer<T> : INatsDeserialize<T>
         var jsonDocument = JsonDocument.Parse(buffer);
         if (jsonDocument.RootElement.TryGetProperty("error", out var errorElement))
         {
-            var error = errorElement.Deserialize(NatsJSJsonSerializerContext.Default.ApiError) ?? throw new NatsJSException("Can't parse JetStream error JSON payload");
+            var error = errorElement.Deserialize(JetStream.NatsJSJsonSerializerContext.Default.ApiError) ?? throw new NatsJSException("Can't parse JetStream error JSON payload");
             throw new NatsJSApiErrorException(error);
         }
 

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -170,6 +170,74 @@ public partial class NatsJSContext
         throw new NatsJSPublishNoResponseException();
     }
 
+    public async ValueTask<NatsJSPublishConcurrentFuture> PublishConcurrentAsync<T>(
+        string subject,
+        T? data,
+        INatsSerialize<T>? serializer = default,
+        NatsJSPubOpts? opts = default,
+        NatsHeaders? headers = default,
+        CancellationToken cancellationToken = default)
+    {
+        if (opts != null)
+        {
+            if (opts.MsgId != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Msg-Id"] = opts.MsgId;
+            }
+
+            if (opts.ExpectedLastMsgId != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Expected-Last-Msg-Id"] = opts.ExpectedLastMsgId;
+            }
+
+            if (opts.ExpectedStream != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Expected-Stream"] = opts.ExpectedStream;
+            }
+
+            if (opts.ExpectedLastSequence != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Expected-Last-Sequence"] = opts.ExpectedLastSequence.ToString();
+            }
+
+            if (opts.ExpectedLastSubjectSequence != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Expected-Last-Subject-Sequence"] = opts.ExpectedLastSubjectSequence.ToString();
+            }
+        }
+
+        opts ??= NatsJSPubOpts.Default;
+
+        var sub = await Connection.RequestSubAsync<T, PubAckResponse>(
+                    subject: subject,
+                    data: data,
+                    headers: headers,
+                    requestSerializer: serializer,
+                    replySerializer: NatsJSJsonSerializer<PubAckResponse>.Default,
+                    requestOpts: opts,
+                    replyOpts: new NatsSubOpts
+                    {
+                        // It's important to set the timeout here so that the subscription can be
+                        // stopped if the server doesn't respond or more likely case is that if there
+                        // is a reconnect to the cluster between the request and waiting for a response,
+                        // without the timeout the publish call will hang forever since the server
+                        // which received the request won't be there to respond anymore.
+                        Timeout = Connection.Opts.RequestTimeout,
+
+                        // If JetStream is disabled, a no responders error will be returned
+                        // No responders error might also happen when reconnecting to cluster
+                        ThrowIfNoResponders = true,
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false);
+        return new NatsJSPublishConcurrentFuture(sub);
+    }
+
     internal static void ThrowIfInvalidStreamName([NotNull] string? name, [CallerArgumentExpression("name")] string? paramName = null)
     {
 #if NETSTANDARD

--- a/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
@@ -3,9 +3,9 @@ using System.Text.Json.Serialization;
 using NATS.Client.Core;
 using NATS.Client.JetStream.Models;
 
-namespace NATS.Client.JetStream.Internal;
+namespace NATS.Client.JetStream;
 
-internal static class NatsJSJsonSerializer<T>
+public static class NatsJSJsonSerializer<T>
 {
 #if NET6_0
     public static readonly INatsSerializer<T> Default = new NatsJsonContextSerializer<T>(NatsJSJsonSerializerContext.Default);

--- a/src/NATS.Client.JetStream/NatsJSPublishConcurrentFuture.cs
+++ b/src/NATS.Client.JetStream/NatsJSPublishConcurrentFuture.cs
@@ -1,0 +1,28 @@
+using NATS.Client.Core;
+using NATS.Client.JetStream.Models;
+
+namespace NATS.Client.JetStream;
+
+public readonly struct NatsJSPublishConcurrentFuture : IAsyncDisposable
+{
+    private readonly NatsSub<PubAckResponse> _sub;
+
+    public NatsJSPublishConcurrentFuture(NatsSub<PubAckResponse> sub) => _sub = sub;
+
+    public async ValueTask<PubAckResponse> GetResponseAsync(CancellationToken cancellationToken = default)
+    {
+        await foreach (var msg in _sub.Msgs.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (msg.Data == null)
+            {
+                throw new NatsJSException("No response data received");
+            }
+
+            return msg.Data;
+        }
+
+        throw new NatsJSPublishNoResponseException();
+    }
+
+    public async ValueTask DisposeAsync() => await _sub.DisposeAsync();
+}

--- a/tests/NATS.Client.JetStream.Tests/PublishConcurrentTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/PublishConcurrentTests.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+using NATS.Client.Core.Tests;
+
+namespace NATS.Client.JetStream.Tests;
+
+public class PublishConcurrentTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public PublishConcurrentTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task Publish_concurrently()
+    {
+        await using var server = NatsServer.StartJS();
+        await using var nats = server.CreateClientConnection();
+        var js = new NatsJSContext(nats);
+
+        await js.CreateStreamAsync("s1", ["s1.>"]);
+
+        // Standard publish
+        {
+            var ack = await js.PublishAsync("s1.foo", 1);
+            Assert.Null(ack.Error);
+            Assert.Equal(1, (int)ack.Seq);
+            Assert.Equal("s1", ack.Stream);
+            Assert.False(ack.Duplicate);
+            Assert.True(ack.IsSuccess());
+            _output.WriteLine($"Published: {ack}");
+        }
+
+        // Concurrently publish
+        {
+            await using var future = await js.PublishConcurrentAsync("s1.foo", 2);
+            var ack = await future.GetResponseAsync();
+            _output.WriteLine($"Published: {ack}");
+        }
+
+        // Compare the performance
+        var stopwatch1 = Stopwatch.StartNew();
+        for (var i = 0; i < 1_000; i++)
+        {
+            var ack = await js.PublishAsync("s1.foo.single", i);
+            ack.EnsureSuccess();
+        }
+
+        _output.WriteLine($"PublishAsync: {stopwatch1.Elapsed}");
+
+        // Concurrently, publish a batch
+        var stopwatch2 = Stopwatch.StartNew();
+        var futures = new NatsJSPublishConcurrentFuture[1_000];
+        for (var i = 0; i < 1_000; i++)
+        {
+            futures[i] = await js.PublishConcurrentAsync("s1.foo.concurrent", i);
+        }
+
+        for (var i = 0; i < 1_000; i++)
+        {
+            await using var future = futures[i];
+            var ack = await future.GetResponseAsync();
+            ack.EnsureSuccess();
+        }
+
+        _output.WriteLine($"PublishConcurrentAsync: {stopwatch2.Elapsed}");
+
+        Assert.True(stopwatch1.Elapsed > stopwatch2.Elapsed);
+
+        await Retry.Until(
+            "stream count settles down",
+            async () => (await js.GetStreamAsync("s1")).Info.State.Messages == 2 + 1_000 + 1_000);
+    }
+}

--- a/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
@@ -87,5 +87,7 @@ public class NatsKVContextFactoryTest
         public IAsyncEnumerable<INatsJSStream> ListStreamsAsync(string? subject = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public IAsyncEnumerable<string> ListStreamNamesAsync(string? subject = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public ValueTask<NatsJSPublishConcurrentFuture> PublishConcurrentAsync<T>(string subject, T? data, INatsSerialize<T>? serializer = default, NatsJSPubOpts? opts = default, NatsHeaders? headers = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }

--- a/tests/NATS.Client.ObjectStore.Tests/NatsObjContextFactoryTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/NatsObjContextFactoryTest.cs
@@ -87,5 +87,7 @@ public class NatsObjContextFactoryTest
         public IAsyncEnumerable<INatsJSStream> ListStreamsAsync(string? subject = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public IAsyncEnumerable<string> ListStreamNamesAsync(string? subject = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public ValueTask<NatsJSPublishConcurrentFuture> PublishConcurrentAsync<T>(string subject, T? data, INatsSerialize<T>? serializer = default, NatsJSPubOpts? opts = default, NatsHeaders? headers = default, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }

--- a/tests/NATS.Client.Platform.Windows.Tests/BasicTests.cs
+++ b/tests/NATS.Client.Platform.Windows.Tests/BasicTests.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace NATS.Client.Platform.Windows.Tests;
 
-public class BasicTests(ITestOutputHelper output)
+public class BasicTests
 {
     [Fact]
     public async Task Core()

--- a/tests/NATS.Client.Platform.Windows.Tests/TlsTests.cs
+++ b/tests/NATS.Client.Platform.Windows.Tests/TlsTests.cs
@@ -14,7 +14,7 @@ using X509Certificate = System.Security.Cryptography.X509Certificates.X509Certif
 
 namespace NATS.Client.Platform.Windows.Tests;
 
-public class TlsTests(ITestOutputHelper output)
+public class TlsTests
 {
     [Fact]
     public async Task Tls_fails_without_certificates()


### PR DESCRIPTION
(apologies for attaching too many reviewers. please review if you have the time)

| Method                   | Batch | Mean         | Error         | StdDev      | Gen0     | Gen1     | Gen2    | Allocated  |
|------------------------- |------ |-------------:|--------------:|------------:|---------:|---------:|--------:|-----------:|
| PublishAsync             | 1     |     151.0 us |      34.13 us |     1.87 us |   0.2441 |        - |       - |    3.81 KB |
| PublishConcurrentlyAsync | 1     |     150.7 us |      57.45 us |     3.15 us |   0.2441 |        - |       - |    3.79 KB |
| PublishAsync             | 10    |   1,319.3 us |     149.59 us |     8.20 us |   1.9531 |        - |       - |   36.43 KB |
| PublishConcurrentlyAsync | 10    |     249.9 us |      29.56 us |     1.62 us |   2.4414 |   0.4883 |       - |   33.16 KB |
| PublishAsync             | 1000  | 132,975.9 us | 169,057.14 us | 9,266.59 us |        - |        - |       - | 3625.81 KB |
| PublishConcurrentlyAsync | 1000  |   9,614.4 us |   9,029.37 us |   494.93 us | 265.6250 | 109.3750 | 46.8750 | 3277.29 KB |

```csharp
var futures = new NatsJSPublishConcurrentFuture[Batch];

for (var i = 0; i < Batch; i++)
{
    futures[i] = await _js.PublishConcurrentAsync("bench_test2", i);
}

for (var i = 0; i < Batch; i++)
{
    await using var future = futures[i];
    var ack = await future.GetResponseAsync();
    ack.EnsureSuccess();
}
```

* resolves #523
* resolves #375