### PR TITLE
Fix il2cpp error (take 2)

### DIFF
--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -11,11 +11,11 @@ namespace NATS.Client.Core.Internal;
 [SkipLocalsInit]
 internal sealed class NuidWriter
 {
-    internal const nuint NuidLength = PrefixLength + SequentialLength;
-    private const nuint Base = 62;
+    internal const uint NuidLength = PrefixLength + SequentialLength;
+    private const uint Base = 62;
     private const ulong MaxSequential = 839299365868340224; // 62^10
     private const uint PrefixLength = 12;
-    private const nuint SequentialLength = 10;
+    private const uint SequentialLength = 10;
     private const int MinIncrement = 33;
     private const int MaxIncrement = 333;
 

--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -11,6 +11,11 @@ namespace NATS.Client.Core.Internal;
 [SkipLocalsInit]
 internal sealed class NuidWriter
 {
+    // NuidLength, PrefixLength, SequentialLength were nuint (System.UIntPtr) in the original code
+    // however, they were changed to uint to fix the compilation error for IL2CPP Unity projects.
+    // With nuint, the following error occurs in Unity Linux IL2CPP builds:
+    //   Error: IL2CPP error for method 'System.Char[] NATS.Client.Core.Internal.NuidWriter::Refresh(System.UInt64&)'
+    //   System.ArgumentOutOfRangeException: Cannot create a constant value for types of System.UIntPtr
     internal const uint NuidLength = PrefixLength + SequentialLength;
     private const uint Base = 62;
     private const ulong MaxSequential = 839299365868340224; // 62^10

--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -144,13 +144,13 @@ internal sealed class NuidWriter
         }
 
         return RefreshAndWrite(nuidBuffer);
-    }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private bool RefreshAndWrite(Span<char> buffer)
-    {
-        var prefix = Refresh(out var sequential);
-        return TryWriteNuidCore(buffer, prefix, sequential);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        bool RefreshAndWrite(Span<char> buffer)
+        {
+            var prefix = Refresh(out sequential);
+            return TryWriteNuidCore(buffer, prefix, sequential);
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Previous commit about this issue reverted since it wasn't fixing the issue. The actual error was:

```
Error: IL2CPP error for method 'System.Char[] NATS.Client.Core.Internal.NuidWriter::Refresh(System.UInt64&)' in assembly NATS.Client.Core.dll
System.ArgumentOutOfRangeException:
 Cannot create a constant value for types of System.UIntPtr for System.UIntPtr NATS.Client.Core.Internal.NuidWriter::NuidLength (Parameter 'declaredParameterOrFieldType')
```

With this fix now it compiles fine:
![image](https://github.com/nats-io/nats.net.v2/assets/386903/40902e81-230b-4bc8-b429-0f3df85a82de)

Looking at Unsafe.Add examples passing in uint or int instead of nuint is fine:

e.g. https://github.com/dotnet/runtime/blob/a7efcd9ca9255dc9faa8b4a2761cdfdb62619610/src/libraries/System.Private.CoreLib/src/System/Buffer.cs#L84

 Note: I had to revert the last two commits (so ignore the previous four commits) to main which was done by mistake without PRs.

cc @galvesribeiro
