### PR TITLE
Use string.Create when building a new inbox string

### DIFF
--- a/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
+++ b/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
@@ -7,9 +7,7 @@ using NATS.Client.Core.Internal;
 namespace MicroBenchmark;
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net60)]
-[SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net80, baseline: true)]
 [SimpleJob(RuntimeMoniker.NativeAot80)]
 public class NewInboxBenchmarks
 {

--- a/src/NATS.Client.Core/Internal/NuidWriter.cs
+++ b/src/NATS.Client.Core/Internal/NuidWriter.cs
@@ -99,6 +99,13 @@ internal sealed class NuidWriter
 
     private static char[] GetPrefix(RandomNumberGenerator? rng = null)
     {
+#if NET8_0_OR_GREATER
+        if (rng == null)
+        {
+            return RandomNumberGenerator.GetItems(Digits, (int)PrefixLength);
+        }
+#endif
+
 #if NETSTANDARD2_0
         var randomBytes = new byte[(int)PrefixLength];
 
@@ -109,8 +116,6 @@ internal sealed class NuidWriter
         }
 #else
         Span<byte> randomBytes = stackalloc byte[(int)PrefixLength];
-
-        // TODO: For .NET 8+, use GetItems for better distribution
         if (rng == null)
         {
             RandomNumberGenerator.Fill(randomBytes);

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using NATS.Client.Core.Internal;
 
@@ -105,44 +104,29 @@ public partial class NatsConnection
         }
     }
 
-#if NETSTANDARD2_0
-    internal static string NewInbox(string prefix) => NewInbox(prefix.AsSpan());
-#endif
-
     [SkipLocalsInit]
-    internal static string NewInbox(ReadOnlySpan<char> prefix)
+    internal static string NewInbox(string prefix)
     {
-        Span<char> buffer = stackalloc char[64];
-        var separatorLength = prefix.Length > 0 ? 1u : 0u;
-        var totalLength = (uint)prefix.Length + (uint)NuidWriter.NuidLength + separatorLength;
-        if (totalLength <= buffer.Length)
+        static void WriteBuffer(Span<char> buffer, (string prefix, int pfxLen) state)
         {
-            buffer = buffer.Slice(0, (int)totalLength);
-        }
-        else
-        {
-            buffer = new char[totalLength];
-        }
-
-        var totalPrefixLength = (uint)prefix.Length + separatorLength;
-        if ((uint)buffer.Length > totalPrefixLength && (uint)buffer.Length > (uint)prefix.Length)
-        {
-            prefix.CopyTo(buffer);
-            buffer[prefix.Length] = '.';
-            var remaining = buffer.Slice((int)totalPrefixLength);
+            state.prefix.AsSpan().CopyTo(buffer);
+            buffer[state.prefix.Length] = '.';
+            var remaining = buffer.Slice(state.pfxLen);
             var didWrite = NuidWriter.TryWriteNuid(remaining);
             Debug.Assert(didWrite, "didWrite");
-            return buffer.ToString();
         }
 
-        return Throw();
+        var separatorLength = prefix.Length > 0 ? 1 : 0;
+        var totalLength = prefix.Length + (int)NuidWriter.NuidLength + separatorLength;
+        var totalPrefixLength = prefix.Length + separatorLength;
 
-        [DoesNotReturn]
-        string Throw()
-        {
-            Debug.Fail("Must not happen");
-            throw new InvalidOperationException("This should never be raised!");
-        }
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
+        return string.Create(totalLength, (prefix, totalPrefixLength), (buf, state) => WriteBuffer(buf, state));
+#else
+        Span<char> buffer = new char[totalLength];
+        WriteBuffer(buffer, (prefix, totalPrefixLength));
+        return buffer.ToString();
+#endif
     }
 
     private NatsSubOpts SetReplyOptsDefaults(NatsSubOpts? replyOpts)

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -1,10 +1,6 @@
-using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
-using System.Threading.Channels;
-using Xunit.Sdk;
 
 namespace NATS.Client.Core.Tests;
 
@@ -382,6 +378,39 @@ public abstract partial class NatsConnectionTest
 
             interfaceMethods.Select(m => m.Name).Should().Contain(name);
         }
+    }
+
+    [Fact]
+    public void NewInboxEmptyPrefixReturnsNuid()
+    {
+        var opts = NatsOpts.Default with { InboxPrefix = "" };
+        var conn = new NatsConnection(opts);
+
+        var inbox = conn.NewInbox();
+
+        Assert.Matches("[A-z0-9]{22}", inbox);
+    }
+
+    [Fact]
+    public void NewInboxNonEmptyPrefixReturnsPrefixWithNuid()
+    {
+        var opts = NatsOpts.Default with { InboxPrefix = "PREFIX" };
+        var conn = new NatsConnection(opts);
+
+        var inbox = conn.NewInbox();
+
+        Assert.Matches("PREFIX\\.[A-z0-9]{22}", inbox);
+    }
+
+    [Fact]
+    public void NewInboxVeryLongPrefixReturnsPrefixWithNuid()
+    {
+        var opts = NatsOpts.Default with { InboxPrefix = new string('A', 512) };
+        var conn = new NatsConnection(opts);
+
+        var inbox = conn.NewInbox();
+
+        Assert.Matches("A{512}\\.[A-z0-9]{22}", inbox);
     }
 }
 

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -383,7 +383,7 @@ public abstract partial class NatsConnectionTest
     [Fact]
     public void NewInboxEmptyPrefixReturnsNuid()
     {
-        var opts = NatsOpts.Default with { InboxPrefix = "" };
+        var opts = NatsOpts.Default with { InboxPrefix = string.Empty };
         var conn = new NatsConnection(opts);
 
         var inbox = conn.NewInbox();

--- a/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
+++ b/tests/NATS.Client.Core.Tests/NuidWriterTests.cs
@@ -17,11 +17,10 @@ public class NuidWriterTests
     }
 
     [Theory]
-    [InlineData(default(string))]
     [InlineData("")]
     [InlineData("__INBOX")]
     [InlineData("long-inbox-prefix-above-stackalloc-limit-of-64")]
-    public void NewInbox_NuidAppended(string? prefix)
+    public void NewInbox_NuidAppended(string prefix)
     {
         var natsOpts = NatsOpts.Default with { InboxPrefix = prefix! };
         var sut = new NatsConnection(natsOpts);
@@ -29,8 +28,8 @@ public class NuidWriterTests
         var inbox = sut.InboxPrefix;
         var newInbox = sut.NewInbox();
 
-        Assert.Matches($"{prefix ?? string.Empty}{(prefix?.Length > 0 ? "." : string.Empty)}[A-z0-9]{{22}}", inbox);
-        Assert.Matches($"{prefix ?? string.Empty}{(prefix?.Length > 0 ? "." : string.Empty)}[A-z0-9]{{22}}.[A-z0-9]{{22}}", newInbox);
+        Assert.Matches($"{prefix}{(prefix.Length > 0 ? "." : string.Empty)}[A-z0-9]{{22}}", inbox);
+        Assert.Matches($"{prefix}{(prefix.Length > 0 ? "." : string.Empty)}[A-z0-9]{{22}}.[A-z0-9]{{22}}", newInbox);
         _outputHelper.WriteLine($"Prefix:   '{prefix}'");
         _outputHelper.WriteLine($"Inbox:    '{inbox}'");
         _outputHelper.WriteLine($"NewInbox: '{newInbox}'");


### PR DESCRIPTION
Use a more idiomatic implementation for `NewInbox` and improve performance.
| Method               | Rev | Runtime       | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------------- |---- |-------------- |---------:|---------:|---------:|-------:|----------:|
| TryWriteNuid         |Base | .NET 8.0      | 31.92 ns | 0.672 ns | 0.800 ns |      - |         - |
| TryWriteNuid         |PR   | .NET 8.0      | 30.66 ns | 0.650 ns | 1.171 ns |      - |         - |
| NewInbox_ShortPrefix |Base | .NET 8.0      | 59.64 ns | 1.258 ns | 1.921 ns | 0.0612 |     128 B |
| NewInbox_ShortPrefix |PR   | .NET 8.0      | 46.89 ns | 0.945 ns | 1.865 ns | 0.0612 |     128 B |
| NewInbox_LongPrefix  |Base | .NET 8.0      | 79.69 ns | 1.674 ns | 4.230 ns | 0.1988 |     416 B |
| NewInbox_LongPrefix  |PR   | .NET 8.0      | 49.29 ns | 1.052 ns | 2.331 ns | 0.0994 |     208 B |
| TryWriteNuid         |Base | NativeAOT 8.0 | 27.82 ns | 0.468 ns | 0.520 ns |      - |         - |
| TryWriteNuid         |PR   | NativeAOT 8.0 | 26.19 ns | 0.527 ns | 0.467 ns |      - |         - |
| NewInbox_ShortPrefix |Base | NativeAOT 8.0 | 54.16 ns | 0.955 ns | 0.981 ns | 0.0612 |     128 B |
| NewInbox_ShortPrefix |PR   | NativeAOT 8.0 | 46.18 ns | 0.925 ns | 0.908 ns | 0.0612 |     128 B |
| NewInbox_LongPrefix  |Base | NativeAOT 8.0 | 71.15 ns | 0.700 ns | 0.621 ns | 0.1988 |     416 B |
| NewInbox_LongPrefix  |PR   | NativeAOT 8.0 | 49.10 ns | 0.748 ns | 0.625 ns | 0.0994 |     208 B |

Looks like tests target .NET6/8 only. I think that the NETSTANDARD2_0 path works too, but I don't have a setup to test that 🤞

6299995a4a2d75c913d9bf8c858f61ae27d53960 is only tangentially related but I thought I could sneak it in.