### PR TITLE
Add repository rename announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+### :mega: :warning: This repository will be renamed to `nats.net` on Wednesday, July 17th, 2024
+
+Please be prepared to update your references to the new name.
+You can also read the [announcement](REPO_RENAME.md) for more information.
+
+---
+
 [![License Apache 2.0](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![NuGet](https://img.shields.io/nuget/v/NATS.Net.svg?cacheSeconds=3600)](https://www.nuget.org/packages/NATS.Net)
 

--- a/REPO_RENAME.md
+++ b/REPO_RENAME.md
@@ -1,0 +1,22 @@
+# This repository will be renamed to `nats.net` on Wednesday, July 17th, 2024
+
+We wanted to let you know about an upcoming rename to our NATS .NET GitHub repositories on Wednesday, July 17. Here's what's changing:
+
+* V1 Current: `nats-io/nats.net` New: `nats-io/nats.net.v1`
+* V2 Current: `nats-io/nats.net.v2` New: `nats-io/nats.net`
+
+We're renaming them to enhance clarity and to help build a consistent NATS .NET brand.
+This change is important to us because it helps prevent confusion for our developers and users,
+especially new folks joining us. Plus, it supports our goal of growing the NATS .NET community.
+
+We recommend using NATS .NET v2, but please rest assured that we will continue to support and maintain v1 as usual.
+
+We'll be making these updates around 1 PM ET (GMT-5) on that day. The good news is that we don’t expect any
+disruptions, as package delivery is handled through NuGet.
+
+If you have bookmarks to the current repositories or their documentation (GitHub pages), please be prepared
+to update them. GitHub will automatically redirect `nats-io/nats.net.v2` to `nats-io/nats.net`, but unfortunately,
+it won't do the same for the v1 repository. Also, if you’ve forked these repositories, you'll need to update
+your upstream remotes for Git.
+
+Thank you for your understanding and continued support!


### PR DESCRIPTION
Added an announcement about the upcoming rename of the current repository to `nats.net`. This change is reflected in a new file REPO_RENAME.md, detailing the rationale behind the renaming and its impact on developers. Also updated the README.md file to include a warning about the impending rename and a link to the announcement.